### PR TITLE
Support solver placeholder policies

### DIFF
--- a/CODING_PROCESS.md
+++ b/CODING_PROCESS.md
@@ -196,7 +196,7 @@ This diagram shows how data is transformed at each stage of the pipeline:
   - `${VAR}` and `${VAR[i]}` default to `ERROR` for empty/missing and non-numeric values.
   - `${VAR:n}` uses numeric default `n` for empty/missing values.
   - `${VAR:INC}` sets the derived response to `CODING_INCOMPLETE` for empty/missing values.
-  - `${VAR:n:m}`, `${VAR:n:INC}`, `${VAR:ERROR:m}` configure empty/missing and non-numeric values separately.
+  - `${VAR:n:m}`, `${VAR:n:INC}`, `${VAR:INC:m}`, `${VAR:ERROR:m}` configure empty/missing and non-numeric values separately.
 
 ### 7. **CODING Stage**
 - **Module**: `src/coding-factory.ts`

--- a/CODING_PROCESS.md
+++ b/CODING_PROCESS.md
@@ -192,6 +192,11 @@ This diagram shows how data is transformed at each stage of the pipeline:
   - `ATTACHMENT`: Attach source values
   - `CONCAT_CODE`: Concatenate source codes
   - `CONCAT_TEXT`: Concatenate source values as text
+- **SOLVER source references**:
+  - `${VAR}` and `${VAR[i]}` default to `ERROR` for empty/missing and non-numeric values.
+  - `${VAR:n}` uses numeric default `n` for empty/missing values.
+  - `${VAR:INC}` sets the derived response to `CODING_INCOMPLETE` for empty/missing values.
+  - `${VAR:n:m}`, `${VAR:n:INC}`, `${VAR:ERROR:m}` configure empty/missing and non-numeric values separately.
 
 ### 7. **CODING Stage**
 - **Module**: `src/coding-factory.ts`

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -78,6 +78,7 @@ Solver expressions reference source variables with `${VAR}` or source fragments 
 | `${VAR:INC}` | `CODING_INCOMPLETE` | `DERIVE_ERROR` |
 | `${VAR:n:m}` | numeric default `n` | numeric default `m` |
 | `${VAR:n:INC}` | numeric default `n` | `CODING_INCOMPLETE` |
+| `${VAR:INC:m}` | `CODING_INCOMPLETE` | numeric default `m` |
 | `${VAR:ERROR:m}` | `DERIVE_ERROR` | numeric default `m` |
 
 The same policy syntax works for fragments, for example `${VAR[0]:0:INC}`.

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -67,6 +67,21 @@ INPUT → GROUP → NORMALIZE → RESOLVE → PLAN → DERIVE → CODE → OUTPU
 | `SOLVER` | Math expression | `V1 + V2 * 3` |
 | `CONCAT_TEXT` | Concatenate text | Combined responses |
 
+### SOLVER Placeholders
+
+Solver expressions reference source variables with `${VAR}` or source fragments with `${VAR[i]}`. Empty/missing values and non-numeric values default to `ERROR`, so `${VAR}` behaves like `${VAR:ERROR:ERROR}`.
+
+| Syntax | Empty/missing value | Non-numeric value |
+|--------|---------------------|-------------------|
+| `${VAR}` | `DERIVE_ERROR` | `DERIVE_ERROR` |
+| `${VAR:n}` | numeric default `n` | `DERIVE_ERROR` |
+| `${VAR:INC}` | `CODING_INCOMPLETE` | `DERIVE_ERROR` |
+| `${VAR:n:m}` | numeric default `n` | numeric default `m` |
+| `${VAR:n:INC}` | numeric default `n` | `CODING_INCOMPLETE` |
+| `${VAR:ERROR:m}` | `DERIVE_ERROR` | numeric default `m` |
+
+The same policy syntax works for fragments, for example `${VAR[0]:0:INC}`.
+
 ### Rule Types
 
 | Rule | Description | Example |

--- a/src/derive/derive-value.ts
+++ b/src/derive/derive-value.ts
@@ -20,7 +20,11 @@ const deriveErrorResponse = (coding: VariableCodingData, subform: string | undef
   subform
 };
 
-export const amountFalseStates = (coding: VariableCodingData, sourceResponses: Response[]): number => {
+export const amountFalseStates = (
+  coding: VariableCodingData,
+  sourceResponses: Response[],
+  variableCodings: VariableCodingData[] = []
+): number => {
   switch (coding.sourceType) {
     case 'MANUAL': {
       const isInvalid = (r: Response) => !MANUAL_VALID_STATES
@@ -38,8 +42,13 @@ export const amountFalseStates = (coding: VariableCodingData, sourceResponses: R
     case 'COPY_VALUE':
     case 'UNIQUE_VALUES':
     case 'SOLVER': {
+      const codingById = new Map(variableCodings.map(c => [c.id, c] as const));
       const isInvalid = (r: Response) => !COPY_SOLVER_VALID_STATES
-        .includes(r.status as (typeof COPY_SOLVER_VALID_STATES)[number]);
+        .includes(r.status as (typeof COPY_SOLVER_VALID_STATES)[number]) &&
+        !(coding.sourceType === 'SOLVER' &&
+          r.status === CODING_SCHEME_STATUS.INVALID &&
+          codingById.get(r.id)?.sourceType === 'BASE' &&
+          isSolverEmptyValue(r.value));
       return sourceResponses.filter(isInvalid).length;
     }
 
@@ -67,13 +76,35 @@ type DeriveContext = {
 type SolverReplacement = {
   sourceId: string;
   fragmentIndex?: number;
+  emptyPolicy: SolverValuePolicy;
+  nonNumericPolicy: SolverValuePolicy;
 };
 
 type SolverToken = {
   text: string;
   variableAlias: string;
   fragmentIndex?: number;
+  emptyPolicy: SolverValuePolicy;
+  nonNumericPolicy: SolverValuePolicy;
 };
+
+type SolverValuePolicy =
+  | { kind: 'ERROR' }
+  | { kind: 'INC' }
+  | { kind: 'DEFAULT'; value: number };
+
+type SolverValueResolution =
+  | { kind: 'value'; value: number }
+  | { kind: 'empty' }
+  | { kind: 'nonNumeric' }
+  | { kind: 'deriveError' };
+
+const SOLVER_ERROR_POLICY: SolverValuePolicy = { kind: 'ERROR' };
+
+const isSolverEmptyValue = (value: Response['value']): boolean => (
+  value === null ||
+  (typeof value === 'string' && value.trim() === '')
+);
 
 const handleManual = ({ coding, sourceResponses, subformSource }: DeriveContext): Response => {
   if (sourceResponses.every(r => r.status === CODING_SCHEME_STATUS.INTENDED_INCOMPLETE)) {
@@ -216,9 +247,44 @@ const isDigit = (char: string): boolean => {
   return code >= 48 && code <= 57;
 };
 
+const parseSolverValuePolicy = (text: string): SolverValuePolicy | null => {
+  const trimmed = text.trim();
+  const normalized = trimmed.toUpperCase();
+
+  if (normalized === 'ERROR') {
+    return SOLVER_ERROR_POLICY;
+  }
+
+  if (normalized === 'INC') {
+    return { kind: 'INC' };
+  }
+
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  const defaultValue = CodingFactory.getValueAsNumber(trimmed);
+  return defaultValue === null ? null : { kind: 'DEFAULT', value: defaultValue };
+};
+
 const parseSolverToken = (text: string, content: string): SolverToken | null => {
-  let variableAlias = content.trim();
+  const contentParts = content.split(':');
+  if (contentParts.length > 3) {
+    return null;
+  }
+
+  let variableAlias = contentParts[0].trim();
   let fragmentIndex: number | undefined;
+  const emptyPolicy = contentParts.length > 1 ?
+    parseSolverValuePolicy(contentParts[1]) :
+    SOLVER_ERROR_POLICY;
+  const nonNumericPolicy = contentParts.length > 2 ?
+    parseSolverValuePolicy(contentParts[2]) :
+    SOLVER_ERROR_POLICY;
+
+  if (!emptyPolicy || !nonNumericPolicy) {
+    return null;
+  }
 
   if (variableAlias.endsWith(']')) {
     const fragmentStart = variableAlias.lastIndexOf('[');
@@ -242,11 +308,13 @@ const parseSolverToken = (text: string, content: string): SolverToken | null => 
   return {
     text,
     variableAlias,
-    fragmentIndex
+    fragmentIndex,
+    emptyPolicy,
+    nonNumericPolicy
   };
 };
 
-const getSolverTokens = (solverExpression: string): SolverToken[] => {
+const getSolverTokens = (solverExpression: string): SolverToken[] | null => {
   const tokens: SolverToken[] = [];
   let searchStart = 0;
 
@@ -264,9 +332,10 @@ const getSolverTokens = (solverExpression: string): SolverToken[] => {
     const text = solverExpression.slice(tokenStart, tokenEnd + 1);
     const content = solverExpression.slice(tokenStart + 2, tokenEnd);
     const token = parseSolverToken(text, content);
-    if (token) {
-      tokens.push(token);
+    if (!token) {
+      return null;
     }
+    tokens.push(token);
     searchStart = tokenEnd + 1;
   }
 
@@ -277,41 +346,46 @@ const getFragmentValueAsNumber = (
   response: Response,
   sourceCoding: VariableCodingData | undefined,
   fragmentIndex: number
-): number | null => {
+): SolverValueResolution => {
   if (!sourceCoding || Array.isArray(response.value)) {
-    return null;
+    return { kind: 'deriveError' };
   }
 
   let transformedValue;
   try {
     transformedValue = transformValue(response.value, sourceCoding.fragmenting || '', false);
   } catch (error) {
-    return null;
+    return { kind: 'deriveError' };
   }
   if (!Array.isArray(transformedValue)) {
-    return null;
+    return { kind: 'empty' };
   }
 
   const fragment = transformedValue[fragmentIndex];
-  if (Array.isArray(fragment) || typeof fragment === 'undefined') {
-    return null;
+  if (typeof fragment === 'undefined') {
+    return { kind: 'empty' };
   }
 
   if (typeof fragment === 'string' && fragment.trim() === '') {
-    return null;
+    return { kind: 'empty' };
   }
 
-  return CodingFactory.getValueAsNumber(fragment as ResponseValueSingleType);
+  if (Array.isArray(fragment)) {
+    return { kind: 'deriveError' };
+  }
+
+  const value = CodingFactory.getValueAsNumber(fragment as ResponseValueSingleType);
+  return value === null ? { kind: 'nonNumeric' } : { kind: 'value', value };
 };
 
 const getSolverReplacementValue = (
   replacement: SolverReplacement,
   sourceResponseById: Map<string, Response>,
   sourceCodingById: Map<string, VariableCodingData>
-): number | null => {
+): SolverValueResolution => {
   const responseToReplace = sourceResponseById.get(replacement.sourceId);
   if (!responseToReplace) {
-    return null;
+    return { kind: 'empty' };
   }
 
   if (typeof replacement.fragmentIndex === 'number') {
@@ -323,10 +397,36 @@ const getSolverReplacementValue = (
   }
 
   if (Array.isArray(responseToReplace.value)) {
-    return null;
+    return { kind: 'deriveError' };
   }
 
-  return CodingFactory.getValueAsNumber(responseToReplace.value);
+  if (isSolverEmptyValue(responseToReplace.value)) {
+    return { kind: 'empty' };
+  }
+
+  const value = CodingFactory.getValueAsNumber(responseToReplace.value);
+  return value === null ? { kind: 'nonNumeric' } : { kind: 'value', value };
+};
+
+const handleSolverPolicy = (
+  coding: VariableCodingData,
+  subformSource: string | undefined,
+  policy: SolverValuePolicy
+): Response | number => {
+  if (policy.kind === 'DEFAULT') {
+    return policy.value;
+  }
+
+  if (policy.kind === 'INC') {
+    return <Response>{
+      id: coding.id,
+      value: null,
+      status: CODING_SCHEME_STATUS.CODING_INCOMPLETE,
+      subform: subformSource
+    };
+  }
+
+  return deriveErrorResponse(coding, subformSource);
 };
 
 const handleSolver = ({
@@ -342,6 +442,9 @@ const handleSolver = ({
   const replacements = new Map<string, SolverReplacement>();
 
   const tokens = getSolverTokens(coding.sourceParameters.solverExpression);
+  if (!tokens) {
+    return deriveErrorResponse(coding, subformSource);
+  }
 
   // eslint-disable-next-line no-restricted-syntax
   for (const token of tokens) {
@@ -354,7 +457,9 @@ const handleSolver = ({
     if (!replacements.has(token.text)) {
       replacements.set(token.text, {
         sourceId: matchId,
-        fragmentIndex: token.fragmentIndex
+        fragmentIndex: token.fragmentIndex,
+        emptyPolicy: token.emptyPolicy,
+        nonNumericPolicy: token.nonNumericPolicy
       });
     }
   }
@@ -374,9 +479,22 @@ const handleSolver = ({
 
   // eslint-disable-next-line no-restricted-syntax
   for (const [toReplace, replacement] of replacements.entries()) {
-    const valueToReplace = getSolverReplacementValue(replacement, sourceResponseById, sourceCodingById);
-    if (valueToReplace === null) {
+    const resolvedValue = getSolverReplacementValue(replacement, sourceResponseById, sourceCodingById);
+    if (resolvedValue.kind === 'deriveError') {
       return deriveErrorResponse(coding, subformSource);
+    }
+
+    let valueToReplace: number | Response;
+    if (resolvedValue.kind === 'empty') {
+      valueToReplace = handleSolverPolicy(coding, subformSource, replacement.emptyPolicy);
+    } else if (resolvedValue.kind === 'nonNumeric') {
+      valueToReplace = handleSolverPolicy(coding, subformSource, replacement.nonNumericPolicy);
+    } else {
+      valueToReplace = resolvedValue.value;
+    }
+
+    if (typeof valueToReplace !== 'number') {
+      return valueToReplace;
     }
 
     newExpression = newExpression.split(toReplace).join(valueToReplace.toString(10));
@@ -412,6 +530,7 @@ export const deriveValue = (
   sourceResponses: Response[]
 ): Response => {
   const subformSource = sourceResponses.find(r => r.subform !== undefined)?.subform;
+  const sourceCodingById = new Map(variableCodings.map(c => [c.id, c] as const));
 
   const statusPrecedence: Array<{
     from: CodingSchemeStatus;
@@ -433,9 +552,34 @@ export const deriveValue = (
     { from: CODING_SCHEME_STATUS.INVALID, to: CODING_SCHEME_STATUS.INVALID }
   ];
 
+  const shouldApplyStatusPrecedence = (
+    sourceResponse: Response,
+    mapping: { from: CodingSchemeStatus; to: CodingSchemeStatus }
+  ): boolean => {
+    if (coding.sourceType !== 'SOLVER') {
+      return sourceResponse.status === mapping.from;
+    }
+
+    if (mapping.from === CODING_SCHEME_STATUS.NO_CODING) {
+      return sourceResponse.status === mapping.from &&
+        sourceCodingById.get(sourceResponse.id)?.sourceType !== 'BASE';
+    }
+
+    if (
+      mapping.from === CODING_SCHEME_STATUS.INVALID &&
+      sourceResponse.status === mapping.from &&
+      sourceCodingById.get(sourceResponse.id)?.sourceType === 'BASE' &&
+      isSolverEmptyValue(sourceResponse.value)
+    ) {
+      return false;
+    }
+
+    return sourceResponse.status === mapping.from;
+  };
+
   // eslint-disable-next-line no-restricted-syntax
   for (const mapping of statusPrecedence) {
-    if (sourceResponses.some(r => r.status === mapping.from)) {
+    if (sourceResponses.some(r => shouldApplyStatusPrecedence(r, mapping))) {
       return <Response>{
         id: coding.id,
         value: null,
@@ -463,7 +607,7 @@ export const deriveValue = (
     };
   }
 
-  const falseStates = amountFalseStates(coding, sourceResponses);
+  const falseStates = amountFalseStates(coding, sourceResponses, variableCodings);
 
   if (sourceResponses.length >= falseStates && falseStates > 0) {
     const allHaveSameStatus = sourceResponses.every(r => r.status === sourceResponses[0].status);

--- a/test/unit/coding-scheme-factory.test.ts
+++ b/test/unit/coding-scheme-factory.test.ts
@@ -9,6 +9,8 @@ import { CodingFactory, CodingSchemeFactory } from '../../src';
 import { executeDependencyPlan } from '../../src/derive/dependency-plan';
 import { applyDerivationsAndCoding } from '../../src/derive/derivation-traversal';
 
+const solverRef = (name: string): string => `\${${name}}`;
+
 describe('CodingSchemeFactory', () => {
   test('can be subclassed (covers instance property initialization)', () => {
     class TestFactory extends CodingSchemeFactory {}
@@ -573,6 +575,238 @@ describe('CodingSchemeFactory', () => {
       ];
       const codedOk = CodingSchemeFactory.code(responses, [v1ok]);
       expect(codedOk.find(r => r.id === 'v1')?.status).toBe('VALUE_CHANGED');
+    });
+
+    test('sets DERIVE_ERROR for SOLVER empty source without explicit policy', () => {
+      const source = CodingFactory.createCodingVariable('v1');
+
+      const derived: VariableCodingData = {
+        ...CodingFactory.createCodingVariable('d1'),
+        sourceType: 'SOLVER',
+        deriveSources: ['v1'],
+        sourceParameters: {
+          solverExpression: `${solverRef('v1')} + 1`,
+          processing: []
+        },
+        codes: []
+      } as VariableCodingData;
+
+      const coded = CodingSchemeFactory.code(
+        [{ id: 'v1', value: '', status: 'VALUE_CHANGED' } as Response],
+        [source, derived]
+      );
+
+      const derivedResponse = coded.find(r => r.id === 'd1');
+      expect(derivedResponse?.value).toBeNull();
+      expect(derivedResponse?.status).toBe('DERIVE_ERROR');
+    });
+
+    test('applies SOLVER empty-value default without TAKE_EMPTY_AS_VALID source normalization', () => {
+      const source = CodingFactory.createCodingVariable('v1');
+
+      const derived: VariableCodingData = {
+        ...CodingFactory.createCodingVariable('d1'),
+        sourceType: 'SOLVER',
+        deriveSources: ['v1'],
+        sourceParameters: {
+          solverExpression: `${solverRef('v1:0')} + 1`,
+          processing: []
+        },
+        codes: []
+      } as VariableCodingData;
+
+      const coded = CodingSchemeFactory.code(
+        [{ id: 'v1', value: '', status: 'VALUE_CHANGED' } as Response],
+        [source, derived]
+      );
+
+      const derivedResponse = coded.find(r => r.id === 'd1');
+      expect(derivedResponse?.value).toBe(1);
+      expect(derivedResponse?.status).toBe('NO_CODING');
+    });
+
+    test('applies SOLVER non-numeric default from second policy position without source normalization', () => {
+      const source = CodingFactory.createCodingVariable('v1');
+
+      const derived: VariableCodingData = {
+        ...CodingFactory.createCodingVariable('d1'),
+        sourceType: 'SOLVER',
+        deriveSources: ['v1'],
+        sourceParameters: {
+          solverExpression: `${solverRef('v1:ERROR:5')} + 1`,
+          processing: []
+        },
+        codes: []
+      } as VariableCodingData;
+
+      const coded = CodingSchemeFactory.code(
+        [{ id: 'v1', value: 'abc', status: 'VALUE_CHANGED' } as Response],
+        [source, derived]
+      );
+
+      const derivedResponse = coded.find(r => r.id === 'd1');
+      expect(derivedResponse?.value).toBe(6);
+      expect(derivedResponse?.status).toBe('NO_CODING');
+    });
+
+    test('sets derived response to CODING_INCOMPLETE for SOLVER INC policy without source normalization', () => {
+      const source = CodingFactory.createCodingVariable('v1');
+
+      const derived: VariableCodingData = {
+        ...CodingFactory.createCodingVariable('d1'),
+        sourceType: 'SOLVER',
+        deriveSources: ['v1'],
+        sourceParameters: {
+          solverExpression: `${solverRef('v1:ERROR:INC')} + 1`,
+          processing: []
+        },
+        codes: []
+      } as VariableCodingData;
+
+      const coded = CodingSchemeFactory.code(
+        [{ id: 'v1', value: 'abc', status: 'VALUE_CHANGED' } as Response],
+        [source, derived]
+      );
+
+      const derivedResponse = coded.find(r => r.id === 'd1');
+      expect(derivedResponse?.value).toBeNull();
+      expect(derivedResponse?.status).toBe('CODING_INCOMPLETE');
+    });
+
+    test('does not apply SOLVER default to genuinely INVALID source coding result', () => {
+      const source = CodingFactory.createCodingVariable('v1');
+      source.codes = <CodeData[]>[
+        {
+          id: 'INVALID',
+          score: 0,
+          label: '',
+          type: 'FULL_CREDIT',
+          manualInstruction: '',
+          ruleSetOperatorAnd: false,
+          ruleSets: [
+            {
+              ruleOperatorAnd: false,
+              rules: [{ method: 'MATCH', parameters: ['abc'] }]
+            }
+          ]
+        }
+      ];
+
+      const derived: VariableCodingData = {
+        ...CodingFactory.createCodingVariable('d1'),
+        sourceType: 'SOLVER',
+        deriveSources: ['v1'],
+        sourceParameters: {
+          solverExpression: `${solverRef('v1:ERROR:5')} + 1`,
+          processing: []
+        },
+        codes: []
+      } as VariableCodingData;
+
+      const coded = CodingSchemeFactory.code(
+        [{ id: 'v1', value: 'abc', status: 'VALUE_CHANGED' } as Response],
+        [source, derived]
+      );
+
+      const derivedResponse = coded.find(r => r.id === 'd1');
+      expect(derivedResponse?.value).toBeNull();
+      expect(derivedResponse?.status).toBe('INVALID');
+    });
+
+    test('applies SOLVER empty-value default to incoming empty INVALID base response', () => {
+      const source = CodingFactory.createCodingVariable('v1');
+
+      const derived: VariableCodingData = {
+        ...CodingFactory.createCodingVariable('d1'),
+        sourceType: 'SOLVER',
+        deriveSources: ['v1'],
+        sourceParameters: {
+          solverExpression: `${solverRef('v1:0')} + 1`,
+          processing: []
+        },
+        codes: []
+      } as VariableCodingData;
+
+      const coded = CodingSchemeFactory.code(
+        [{ id: 'v1', value: '', status: 'INVALID' } as Response],
+        [source, derived]
+      );
+
+      const derivedResponse = coded.find(r => r.id === 'd1');
+      expect(derivedResponse?.value).toBe(1);
+      expect(derivedResponse?.status).toBe('NO_CODING');
+    });
+
+    test('applies SOLVER empty-value default to incoming null INVALID base response', () => {
+      const source = CodingFactory.createCodingVariable('v1');
+
+      const derived: VariableCodingData = {
+        ...CodingFactory.createCodingVariable('d1'),
+        sourceType: 'SOLVER',
+        deriveSources: ['v1'],
+        sourceParameters: {
+          solverExpression: `${solverRef('v1:0')} + 1`,
+          processing: []
+        },
+        codes: []
+      } as VariableCodingData;
+
+      const coded = CodingSchemeFactory.code(
+        [{ id: 'v1', value: null, status: 'INVALID' } as Response],
+        [source, derived]
+      );
+
+      const derivedResponse = coded.find(r => r.id === 'd1');
+      expect(derivedResponse?.value).toBe(1);
+      expect(derivedResponse?.status).toBe('NO_CODING');
+    });
+
+    test('applies SOLVER empty-value default to incoming whitespace INVALID base response', () => {
+      const source = CodingFactory.createCodingVariable('v1');
+
+      const derived: VariableCodingData = {
+        ...CodingFactory.createCodingVariable('d1'),
+        sourceType: 'SOLVER',
+        deriveSources: ['v1'],
+        sourceParameters: {
+          solverExpression: `${solverRef('v1:0')} + 1`,
+          processing: []
+        },
+        codes: []
+      } as VariableCodingData;
+
+      const coded = CodingSchemeFactory.code(
+        [{ id: 'v1', value: '   ', status: 'INVALID' } as Response],
+        [source, derived]
+      );
+
+      const derivedResponse = coded.find(r => r.id === 'd1');
+      expect(derivedResponse?.value).toBe(1);
+      expect(derivedResponse?.status).toBe('NO_CODING');
+    });
+
+    test('does not apply SOLVER non-numeric default to incoming non-empty INVALID base response', () => {
+      const source = CodingFactory.createCodingVariable('v1');
+
+      const derived: VariableCodingData = {
+        ...CodingFactory.createCodingVariable('d1'),
+        sourceType: 'SOLVER',
+        deriveSources: ['v1'],
+        sourceParameters: {
+          solverExpression: `${solverRef('v1:ERROR:5')} + 1`,
+          processing: []
+        },
+        codes: []
+      } as VariableCodingData;
+
+      const coded = CodingSchemeFactory.code(
+        [{ id: 'v1', value: 'abc', status: 'INVALID' } as Response],
+        [source, derived]
+      );
+
+      const derivedResponse = coded.find(r => r.id === 'd1');
+      expect(derivedResponse?.value).toBeNull();
+      expect(derivedResponse?.status).toBe('INVALID');
     });
 
     test('maps response ids from alias to id and back to alias', () => {

--- a/test/unit/derive-value.test.ts
+++ b/test/unit/derive-value.test.ts
@@ -359,6 +359,217 @@ describe('deriveValue', () => {
     expect(result.value).toBeNull();
   });
 
+  test('SOLVER keeps array source value as DERIVE_ERROR even with non-numeric default policy', () => {
+    const v1 = CodingFactory.createCodingVariable('ID_1');
+    v1.alias = 'v1';
+    const coding: VariableCodingData = {
+      ...CodingFactory.createCodingVariable('d'),
+      sourceType: 'SOLVER',
+      deriveSources: ['v1'],
+      sourceParameters: {
+        solverExpression: `${solverRef('v1:ERROR:5')} + 1`,
+        processing: []
+      },
+      codes: []
+    } as VariableCodingData;
+
+    const r1: Response = {
+      id: 'v1',
+      value: [1],
+      status: 'VALUE_CHANGED'
+    } as Response;
+
+    const result = deriveValue([coding], coding, [r1]);
+    expect(result.status).toBe('DERIVE_ERROR');
+    expect(result.value).toBeNull();
+  });
+
+  test('SOLVER returns DERIVE_ERROR for empty source value without explicit policy', () => {
+    const v1 = CodingFactory.createCodingVariable('ID_1');
+    v1.alias = 'v1';
+    const coding: VariableCodingData = {
+      ...CodingFactory.createCodingVariable('d'),
+      sourceType: 'SOLVER',
+      deriveSources: ['v1'],
+      sourceParameters: {
+        solverExpression: `${v1} + 1`,
+        processing: []
+      },
+      codes: []
+    } as VariableCodingData;
+
+    const r1: Response = {
+      id: 'v1',
+      value: '',
+      status: 'VALUE_CHANGED'
+    } as Response;
+
+    const result = deriveValue([coding], coding, [r1]);
+    expect(result.status).toBe('DERIVE_ERROR');
+    expect(result.value).toBeNull();
+  });
+
+  test('SOLVER rejects empty policy segment after separator', () => {
+    const coding: VariableCodingData = {
+      ...CodingFactory.createCodingVariable('d'),
+      sourceType: 'SOLVER',
+      deriveSources: ['v1'],
+      sourceParameters: {
+        solverExpression: `${solverRef('v1:')} + 1`,
+        processing: []
+      },
+      codes: []
+    } as VariableCodingData;
+
+    const r1: Response = {
+      id: 'v1',
+      value: '1',
+      status: 'VALUE_CHANGED'
+    } as Response;
+
+    const result = deriveValue([coding], coding, [r1]);
+    expect(result.status).toBe('DERIVE_ERROR');
+    expect(result.value).toBeNull();
+  });
+
+  test('SOLVER rejects omitted empty policy before non-numeric policy', () => {
+    const coding: VariableCodingData = {
+      ...CodingFactory.createCodingVariable('d'),
+      sourceType: 'SOLVER',
+      deriveSources: ['v1'],
+      sourceParameters: {
+        solverExpression: `${solverRef('v1::INC')} + 1`,
+        processing: []
+      },
+      codes: []
+    } as VariableCodingData;
+
+    const r1: Response = {
+      id: 'v1',
+      value: 'abc',
+      status: 'VALUE_CHANGED'
+    } as Response;
+
+    const result = deriveValue([coding], coding, [r1]);
+    expect(result.status).toBe('DERIVE_ERROR');
+    expect(result.value).toBeNull();
+  });
+
+  test('SOLVER can replace empty source value with explicit numeric default', () => {
+    const coding: VariableCodingData = {
+      ...CodingFactory.createCodingVariable('d'),
+      sourceType: 'SOLVER',
+      deriveSources: ['v1'],
+      sourceParameters: {
+        solverExpression: `${solverRef('v1:0')} + 1`,
+        processing: []
+      },
+      codes: []
+    } as VariableCodingData;
+
+    const r1: Response = {
+      id: 'v1',
+      value: '',
+      status: 'VALUE_CHANGED'
+    } as Response;
+
+    const result = deriveValue([coding], coding, [r1]);
+    expect(result.status).toBe('VALUE_CHANGED');
+    expect(result.value).toBe(1);
+  });
+
+  test('SOLVER returns CODING_INCOMPLETE for empty source value with INC policy', () => {
+    const coding: VariableCodingData = {
+      ...CodingFactory.createCodingVariable('d'),
+      sourceType: 'SOLVER',
+      deriveSources: ['v1'],
+      sourceParameters: {
+        solverExpression: `${solverRef('v1:INC')} + 1`,
+        processing: []
+      },
+      codes: []
+    } as VariableCodingData;
+
+    const r1: Response = {
+      id: 'v1',
+      value: '',
+      status: 'VALUE_CHANGED'
+    } as Response;
+
+    const result = deriveValue([coding], coding, [r1]);
+    expect(result.status).toBe('CODING_INCOMPLETE');
+    expect(result.value).toBeNull();
+  });
+
+  test('SOLVER keeps non-numeric source value as DERIVE_ERROR when only empty default is set', () => {
+    const coding: VariableCodingData = {
+      ...CodingFactory.createCodingVariable('d'),
+      sourceType: 'SOLVER',
+      deriveSources: ['v1'],
+      sourceParameters: {
+        solverExpression: `${solverRef('v1:0')} + 1`,
+        processing: []
+      },
+      codes: []
+    } as VariableCodingData;
+
+    const r1: Response = {
+      id: 'v1',
+      value: 'abc',
+      status: 'VALUE_CHANGED'
+    } as Response;
+
+    const result = deriveValue([coding], coding, [r1]);
+    expect(result.status).toBe('DERIVE_ERROR');
+    expect(result.value).toBeNull();
+  });
+
+  test('SOLVER can replace non-numeric source value with second-position numeric default', () => {
+    const coding: VariableCodingData = {
+      ...CodingFactory.createCodingVariable('d'),
+      sourceType: 'SOLVER',
+      deriveSources: ['v1'],
+      sourceParameters: {
+        solverExpression: `${solverRef('v1:ERROR:5')} + 1`,
+        processing: []
+      },
+      codes: []
+    } as VariableCodingData;
+
+    const r1: Response = {
+      id: 'v1',
+      value: 'abc',
+      status: 'VALUE_CHANGED'
+    } as Response;
+
+    const result = deriveValue([coding], coding, [r1]);
+    expect(result.status).toBe('VALUE_CHANGED');
+    expect(result.value).toBe(6);
+  });
+
+  test('SOLVER returns CODING_INCOMPLETE for non-numeric source value with second-position INC policy', () => {
+    const coding: VariableCodingData = {
+      ...CodingFactory.createCodingVariable('d'),
+      sourceType: 'SOLVER',
+      deriveSources: ['v1'],
+      sourceParameters: {
+        solverExpression: `${solverRef('v1:0:INC')} + 1`,
+        processing: []
+      },
+      codes: []
+    } as VariableCodingData;
+
+    const r1: Response = {
+      id: 'v1',
+      value: 'abc',
+      status: 'VALUE_CHANGED'
+    } as Response;
+
+    const result = deriveValue([coding], coding, [r1]);
+    expect(result.status).toBe('CODING_INCOMPLETE');
+    expect(result.value).toBeNull();
+  });
+
   test('SOLVER can use numeric fragments from source variable fragmenting', () => {
     const source = CodingFactory.createCodingVariable('01');
     source.alias = 'FORMEL';
@@ -487,6 +698,84 @@ describe('deriveValue', () => {
 
     const result = deriveValue([source, coding], coding, [r1]);
     expect(result.status).toBe('DERIVE_ERROR');
+    expect(result.value).toBeNull();
+  });
+
+  test('SOLVER can replace missing fragment with explicit numeric default', () => {
+    const source = CodingFactory.createCodingVariable('v1');
+    source.fragmenting = '(\\d+)-(\\d+)';
+
+    const coding: VariableCodingData = {
+      ...CodingFactory.createCodingVariable('d'),
+      sourceType: 'SOLVER',
+      deriveSources: ['v1'],
+      sourceParameters: {
+        solverExpression: `${solverRef('v1[2]:10')} + 1`,
+        processing: []
+      },
+      codes: []
+    } as VariableCodingData;
+
+    const r1: Response = {
+      id: 'v1',
+      value: '3-4',
+      status: 'VALUE_CHANGED'
+    } as Response;
+
+    const result = deriveValue([source, coding], coding, [r1]);
+    expect(result.status).toBe('VALUE_CHANGED');
+    expect(result.value).toBe(11);
+  });
+
+  test('SOLVER keeps non-numeric fragment as DERIVE_ERROR when only empty default is set', () => {
+    const source = CodingFactory.createCodingVariable('v1');
+    source.fragmenting = '(\\d+)-([A-Z]+)';
+
+    const coding: VariableCodingData = {
+      ...CodingFactory.createCodingVariable('d'),
+      sourceType: 'SOLVER',
+      deriveSources: ['v1'],
+      sourceParameters: {
+        solverExpression: `${solverRef('v1[1]:10')} + 1`,
+        processing: []
+      },
+      codes: []
+    } as VariableCodingData;
+
+    const r1: Response = {
+      id: 'v1',
+      value: '3-ABC',
+      status: 'VALUE_CHANGED'
+    } as Response;
+
+    const result = deriveValue([source, coding], coding, [r1]);
+    expect(result.status).toBe('DERIVE_ERROR');
+    expect(result.value).toBeNull();
+  });
+
+  test('SOLVER can apply second-position INC policy to non-numeric fragment', () => {
+    const source = CodingFactory.createCodingVariable('v1');
+    source.fragmenting = '(\\d+)-([A-Z]+)';
+
+    const coding: VariableCodingData = {
+      ...CodingFactory.createCodingVariable('d'),
+      sourceType: 'SOLVER',
+      deriveSources: ['v1'],
+      sourceParameters: {
+        solverExpression: `${solverRef('v1[1]:10:INC')} + 1`,
+        processing: []
+      },
+      codes: []
+    } as VariableCodingData;
+
+    const r1: Response = {
+      id: 'v1',
+      value: '3-ABC',
+      status: 'VALUE_CHANGED'
+    } as Response;
+
+    const result = deriveValue([source, coding], coding, [r1]);
+    expect(result.status).toBe('CODING_INCOMPLETE');
     expect(result.value).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Adds explicit SOLVER placeholder policies for empty/missing and non-numeric source values, including fragment references.

- supports `${VAR:n}`, `${VAR:INC}`, and separate empty/non-numeric policies such as `${VAR:ERROR:n}`
- lets normal empty BASE sources reach SOLVER policy handling without requiring `TAKE_EMPTY_AS_VALID`
- keeps array values structurally invalid instead of defaulting them
- rejects ambiguous empty policy segments such as `${VAR:}` and `${VAR::INC}`
- documents the new placeholder syntax in the quick reference and coding process notes

## Root Cause

Empty BASE responses were normalized before the SOLVER path could apply token-level defaults, and the previous SOLVER value resolution did not distinguish empty/missing values from scalar non-numeric values.

## Validation

- `npm run lint`
- `npm test`
- `npm run prepare_publish`

Related: iqb-berlin/coding-components#161

Note: the related issue is intentionally left open until the responses package is released and consumed by coding-components.
