### PR TITLE
Fix derived alias shadowing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@iqb/responses",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@iqb/responses",
-      "version": "5.1.0",
+      "version": "5.1.1",
       "license": "MIT",
       "dependencies": {
         "@iqbspecs/coding-scheme": "^3.4.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@iqb/responses",
   "author": "IQB - Institut zur Qualitätsentwicklung im Bildungswesen",
   "license": "MIT",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "Automatic coding.",
   "scripts": {
     "test": "jest",

--- a/package_npm.json
+++ b/package_npm.json
@@ -1,6 +1,6 @@
 {
   "name": "@iqb/responses",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "author": "IQB - Institut zur Qualitätsentwicklung im Bildungswesen",
   "license": "CC0 1.0",
   "description": "Automatic coding.",

--- a/src/coding-scheme-factory.ts
+++ b/src/coding-scheme-factory.ts
@@ -15,7 +15,10 @@ import {
   normalizeDisplayedToValueChanged,
   normalizeNotReachedToValueChanged
 } from './normalize/response-status';
-import { removeBaseResponsesShadowedByDerived } from './merge/resolve-derived-conflicts';
+import {
+  removeBaseResponsesShadowedByDerived,
+  removeBaseResponsesShadowedByDerivedAlias
+} from './merge/resolve-derived-conflicts';
 import { finalizeAndDeduplicateResponses } from './finalize/finalize-and-deduplicate';
 
 export type { VariableGraphNode } from './graph/dependency-tree';
@@ -66,9 +69,14 @@ export abstract class CodingSchemeFactory {
           options
         );
 
+        const resolved = removeBaseResponsesShadowedByDerivedAlias(
+          executed,
+          ctx.variableCodings
+        );
+
         return {
           ...ctx,
-          responses: executed
+          responses: resolved
         };
       },
       ctx => ({

--- a/src/mapping/alias-mapper.ts
+++ b/src/mapping/alias-mapper.ts
@@ -1,15 +1,49 @@
 import { Response } from '@iqbspecs/response/response.interface';
 import { VariableCodingData } from '@iqbspecs/coding-scheme';
 
+const isDerivedVariable = (coding: VariableCodingData): boolean => (
+  coding.sourceType !== 'BASE' && coding.sourceType !== 'BASE_NO_VALUE'
+);
+
+const shadowsBaseSourceAlias = (
+  coding: VariableCodingData,
+  shadowedCoding?: VariableCodingData
+): boolean => Boolean(
+  coding.alias &&
+  shadowedCoding &&
+  shadowedCoding.id === coding.alias &&
+  shadowedCoding.sourceType === 'BASE' &&
+  isDerivedVariable(coding) &&
+  (coding.deriveSources ?? []).includes(shadowedCoding.id)
+);
+
+const getAliasMap = (
+  variableCodings: VariableCodingData[]
+): Map<string, string> => {
+  const codingById = new Map(variableCodings.map(coding => [coding.id, coding]));
+  const aliasMap = new Map<string, string>();
+
+  variableCodings
+    .filter(coding => Boolean(coding.alias))
+    .forEach(coding => {
+      const alias = coding.alias as string;
+      const shadowedCoding = codingById.get(alias);
+
+      if (shadowsBaseSourceAlias(coding, shadowedCoding)) {
+        return;
+      }
+
+      aliasMap.set(alias, coding.id);
+    });
+
+  return aliasMap;
+};
+
 export const mapResponseAliasToId = (
   responses: Response[],
   variableCodings: VariableCodingData[]
 ): Response[] => {
-  const aliasMap = new Map(
-    variableCodings
-      .filter(coding => Boolean(coding.alias))
-      .map(coding => [coding.alias as string, coding.id])
-  );
+  const aliasMap = getAliasMap(variableCodings);
   return responses.map(response => ({
     ...response,
     id: aliasMap.get(response.id) || response.id

--- a/src/merge/resolve-derived-conflicts.ts
+++ b/src/merge/resolve-derived-conflicts.ts
@@ -21,3 +21,39 @@ export const removeBaseResponsesShadowedByDerived = (
     return !hasDerivedConflict;
   });
 };
+
+export const removeBaseResponsesShadowedByDerivedAlias = (
+  responses: Response[],
+  variableCodings: VariableCodingData[]
+): Response[] => {
+  const baseCodingIds = new Set(
+    variableCodings
+      .filter(vc => vc.sourceType === 'BASE')
+      .map(vc => vc.id)
+  );
+  const shadowingPairs = variableCodings
+    .filter(vc => (
+      vc.sourceType !== 'BASE' &&
+      vc.sourceType !== 'BASE_NO_VALUE' &&
+      Boolean(vc.alias) &&
+      vc.alias !== vc.id &&
+      baseCodingIds.has(vc.alias as string) &&
+      (vc.deriveSources ?? []).includes(vc.alias as string)
+    ))
+    .map(vc => ({
+      baseId: vc.alias as string,
+      derivedId: vc.id
+    }));
+
+  return responses.filter(response => {
+    const isShadowedBaseResponse = shadowingPairs.some(pair => (
+      response.id === pair.baseId &&
+      responses.some(candidate => (
+        candidate.id === pair.derivedId &&
+        candidate.subform === response.subform
+      ))
+    ));
+
+    return !isShadowedBaseResponse;
+  });
+};

--- a/src/validation/validate-coding-scheme.ts
+++ b/src/validation/validate-coding-scheme.ts
@@ -116,25 +116,76 @@ export const validateCodingScheme = (
   const codingIdCounts = new Map<string, number>();
   const codingAliasCounts = new Map<string, number>();
   const codingIds = new Set<string>();
+  const codingById = new Map<string, VariableCodingData>();
+  const codingsByAlias = new Map<string, VariableCodingData[]>();
   variableCodings.forEach(vc => {
     codingIdCounts.set(vc.id, (codingIdCounts.get(vc.id) ?? 0) + 1);
     codingIds.add(vc.id);
+    codingById.set(vc.id, vc);
     if (vc.alias) {
       codingAliasCounts.set(
         vc.alias,
         (codingAliasCounts.get(vc.alias) ?? 0) + 1
       );
+      codingsByAlias.set(vc.alias, [
+        ...(codingsByAlias.get(vc.alias) ?? []),
+        vc
+      ]);
     }
   });
+
+  const isDerivedVariable = (vc: VariableCodingData): boolean => (
+    vc.sourceType !== 'BASE' && vc.sourceType !== 'BASE_NO_VALUE'
+  );
+
+  const isDerivedShadowingItsBaseSource = (
+    vc: VariableCodingData
+  ): boolean => {
+    if (!vc.alias || vc.alias === vc.id || !isDerivedVariable(vc)) {
+      return false;
+    }
+
+    const shadowedCoding = codingById.get(vc.alias);
+    return Boolean(
+      shadowedCoding &&
+      shadowedCoding.sourceType === 'BASE' &&
+      (vc.deriveSources ?? []).includes(shadowedCoding.id)
+    );
+  };
+
+  const isAllowedAliasShadowingGroup = (alias: string): boolean => {
+    const codingsWithAlias = codingsByAlias.get(alias) ?? [];
+    const shadowedCoding = codingById.get(alias);
+    if (!shadowedCoding || shadowedCoding.sourceType !== 'BASE') {
+      return false;
+    }
+
+    const shadowingCodings = codingsWithAlias.filter(
+      vc => vc.id !== shadowedCoding.id
+    );
+    return (
+      shadowingCodings.length === 1 &&
+      isDerivedShadowingItsBaseSource(shadowingCodings[0])
+    );
+  };
 
   variableCodings.forEach(vc => {
     if ((codingIdCounts.get(vc.id) ?? 0) > 1) {
       pushInvalidSourceProblem(vc.alias || vc.id, vc.label || '');
     }
-    if (vc.alias && (codingAliasCounts.get(vc.alias) ?? 0) > 1) {
+    if (
+      vc.alias &&
+      (codingAliasCounts.get(vc.alias) ?? 0) > 1 &&
+      !isAllowedAliasShadowingGroup(vc.alias)
+    ) {
       pushInvalidSourceProblem(vc.alias || vc.id, vc.label || '');
     }
-    if (vc.alias && codingIds.has(vc.alias) && vc.alias !== vc.id) {
+    if (
+      vc.alias &&
+      codingIds.has(vc.alias) &&
+      vc.alias !== vc.id &&
+      !isDerivedShadowingItsBaseSource(vc)
+    ) {
       pushInvalidSourceProblem(vc.alias || vc.id, vc.label || '');
     }
   });

--- a/test/unit/coding-scheme-factory.test.ts
+++ b/test/unit/coding-scheme-factory.test.ts
@@ -400,6 +400,48 @@ describe('CodingSchemeFactory', () => {
       ).toBe(true);
     });
 
+    test('allows a derived variable to shadow its base source id by alias', () => {
+      const baseVars: VariableInfo[] = [
+        { id: '01', type: 'string' }
+      ] as unknown as VariableInfo[];
+      const base = CodingFactory.createCodingVariable('01');
+      const derived: VariableCodingData = {
+        ...CodingFactory.createCodingVariable('d_1756129659039'),
+        alias: '01',
+        sourceType: 'COPY_VALUE',
+        deriveSources: ['01']
+      } as VariableCodingData;
+
+      const problems = CodingSchemeFactory.validate(baseVars, [base, derived]);
+      expect(
+        problems.some(p => p.type === 'INVALID_SOURCE' && p.breaking)
+      ).toBe(false);
+    });
+
+    test('detects INVALID_SOURCE when an alias shadows a variable that is not a source', () => {
+      const baseVars: VariableInfo[] = [
+        { id: 'source', type: 'string' },
+        { id: 'visible', type: 'string' }
+      ] as unknown as VariableInfo[];
+      const source = CodingFactory.createCodingVariable('source');
+      const visible = CodingFactory.createCodingVariable('visible');
+      const derived: VariableCodingData = {
+        ...CodingFactory.createCodingVariable('derived'),
+        alias: 'visible',
+        sourceType: 'COPY_VALUE',
+        deriveSources: ['source']
+      } as VariableCodingData;
+
+      const problems = CodingSchemeFactory.validate(baseVars, [
+        source,
+        visible,
+        derived
+      ]);
+      expect(
+        problems.some(p => p.type === 'INVALID_SOURCE' && p.breaking)
+      ).toBe(true);
+    });
+
     test('detects MORE_THAN_ONE_SOURCE for COPY_VALUE with multiple sources', () => {
       const baseVars: VariableInfo[] = [
         { id: 'v1' },
@@ -855,6 +897,73 @@ describe('CodingSchemeFactory', () => {
       );
 
       expect(coded[0].id).toBe('ALIAS_1');
+    });
+
+    test('codes derived alias shadowing as a single external variable', () => {
+      const base = CodingFactory.createCodingVariable('01');
+      const derived: VariableCodingData = {
+        ...CodingFactory.createCodingVariable('d_1756129659039'),
+        alias: '01',
+        sourceType: 'COPY_VALUE',
+        deriveSources: ['01'],
+        codes: []
+      } as VariableCodingData;
+
+      const coded = CodingSchemeFactory.code(
+        [{ id: '01', value: 7, status: 'CODING_COMPLETE' } as Response],
+        [base, derived]
+      );
+
+      expect(coded.filter(r => r.id === '01')).toHaveLength(1);
+      expect(coded[0]).toEqual(
+        expect.objectContaining({
+          id: '01',
+          value: 7,
+          status: 'NO_CODING'
+        })
+      );
+    });
+
+    test('codes derived alias shadowing when the base variable has no alias', () => {
+      const base = CodingFactory.createCodingVariable('01');
+      delete base.alias;
+      base.codes = [
+        {
+          id: 1,
+          score: 1,
+          label: '',
+          type: 'FULL_CREDIT',
+          manualInstruction: '',
+          ruleSetOperatorAnd: false,
+          ruleSets: [
+            {
+              ruleOperatorAnd: false,
+              rules: [{ method: 'MATCH', parameters: ['7'] }]
+            }
+          ]
+        }
+      ] as CodeData[];
+      const derived: VariableCodingData = {
+        ...CodingFactory.createCodingVariable('d_1756129659039'),
+        alias: '01',
+        sourceType: 'COPY_VALUE',
+        deriveSources: ['01'],
+        codes: []
+      } as VariableCodingData;
+
+      const coded = CodingSchemeFactory.code(
+        [{ id: '01', value: '7', status: 'VALUE_CHANGED' } as Response],
+        [base, derived]
+      );
+
+      expect(coded).toHaveLength(1);
+      expect(coded[0]).toEqual(
+        expect.objectContaining({
+          id: '01',
+          value: '7',
+          status: 'NO_CODING'
+        })
+      );
     });
 
     test('keeps subforms separated when mapping ids and returning results', () => {

--- a/test/unit/coding-scheme-factory.test.ts
+++ b/test/unit/coding-scheme-factory.test.ts
@@ -966,6 +966,55 @@ describe('CodingSchemeFactory', () => {
       );
     });
 
+    test('codes derived alias shadowing separately per subform', () => {
+      const base = CodingFactory.createCodingVariable('01');
+      const derived: VariableCodingData = {
+        ...CodingFactory.createCodingVariable('d_1756129659039'),
+        alias: '01',
+        sourceType: 'COPY_VALUE',
+        deriveSources: ['01'],
+        codes: []
+      } as VariableCodingData;
+
+      const coded = CodingSchemeFactory.code(
+        [
+          {
+            id: '01',
+            value: 7,
+            status: 'CODING_COMPLETE',
+            subform: 'S1'
+          } as Response,
+          {
+            id: '01',
+            value: 9,
+            status: 'CODING_COMPLETE',
+            subform: 'S2'
+          } as Response
+        ],
+        [base, derived]
+      );
+
+      expect(coded).toHaveLength(2);
+      expect(coded.filter(r => r.id === '01' && r.subform === 'S1')).toHaveLength(1);
+      expect(coded.filter(r => r.id === '01' && r.subform === 'S2')).toHaveLength(1);
+      expect(coded).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: '01',
+            value: 7,
+            status: 'NO_CODING',
+            subform: 'S1'
+          }),
+          expect.objectContaining({
+            id: '01',
+            value: 9,
+            status: 'NO_CODING',
+            subform: 'S2'
+          })
+        ])
+      );
+    });
+
     test('keeps subforms separated when mapping ids and returning results', () => {
       const coding: VariableCodingData = {
         ...CodingFactory.createCodingVariable('ID_1'),


### PR DESCRIPTION
## Summary

- allow derived variables to expose the base variable id as alias when they copy from that base source
- keep incoming base responses available for derivation while returning a single external response id
- add regression coverage for alias shadowing with and without a base alias
- bump package version to 5.1.1

## Root Cause

Coding schemes can use stable internal ids for derived variables while exposing the original base variable id as alias. The previous validation and alias mapping treated that intentional alias/id overlap like an invalid collision, and the coding path could map incoming base responses to the derived id too early.

## Validation

- `npx jest test/unit/coding-scheme-factory.test.ts --runInBand`
- `npm test -- --runInBand`
- `npm run lint`
- `npm run prepare_publish`
- `git diff --check`

Related to iqb-berlin/studio-lite#1463.