### PR TITLE
Strengthen coding scheme validation

### DIFF
--- a/src/validation/validate-coding-scheme.ts
+++ b/src/validation/validate-coding-scheme.ts
@@ -1,9 +1,18 @@
 import {
+  RuleMethod,
   RuleMethodParameterCount,
   VariableCodingData
 } from '@iqbspecs/coding-scheme';
 import { VariableInfo } from '@iqbspecs/variable-info/variable-info.interface';
 import { CodingSchemeProblem } from '../coding-interfaces';
+
+type CodingValueType = 'numeric' | 'boolean' | 'string' | 'other' | 'unknown';
+
+type CodingValueShape = {
+  valueType: CodingValueType;
+  multiple?: boolean;
+  valuePositionLabels?: string[];
+};
 
 export const validateCodingScheme = (
   baseVariables: VariableInfo[],
@@ -11,6 +20,16 @@ export const validateCodingScheme = (
 ): CodingSchemeProblem[] => {
   const baseVarById = new Map<string, VariableInfo>();
   const problems: CodingSchemeProblem[] = [];
+  const numericRuleMethods: RuleMethod[] = [
+    'NUMERIC_MATCH',
+    'NUMERIC_RANGE',
+    'NUMERIC_FULL_RANGE',
+    'NUMERIC_MIN',
+    'NUMERIC_MORE_THAN',
+    'NUMERIC_LESS_THAN',
+    'NUMERIC_MAX'
+  ];
+  const booleanRuleMethods: RuleMethod[] = ['IS_TRUE', 'IS_FALSE'];
 
   const pushRuleParameterMismatch = (
     variableId: string,
@@ -88,6 +107,44 @@ export const validateCodingScheme = (
     return Number.isFinite(n);
   };
 
+  const getCodeRef = (code: { id?: unknown }): string => (
+    typeof code.id !== 'undefined' && code.id !== null ?
+      String(code.id) :
+      'null'
+  );
+
+  const getBaseVariableValueShape = (
+    varInfo: VariableInfo | undefined
+  ): CodingValueShape => {
+    const multiple = varInfo?.multiple;
+    const valuePositionLabels = varInfo?.valuePositionLabels;
+
+    if (!varInfo?.type) {
+      return { valueType: 'unknown', multiple, valuePositionLabels };
+    }
+
+    if (['integer', 'number'].includes(varInfo.type)) {
+      return { valueType: 'numeric', multiple, valuePositionLabels };
+    }
+
+    if (varInfo.type === 'boolean') {
+      return { valueType: 'boolean', multiple, valuePositionLabels };
+    }
+
+    if (varInfo.type === 'string') {
+      return { valueType: 'string', multiple, valuePositionLabels };
+    }
+
+    return { valueType: 'other', multiple, valuePositionLabels };
+  };
+
+  const isKnownIncompatibleType = (
+    valueType: CodingValueType,
+    expectedType: CodingValueType
+  ): boolean => (
+    valueType !== 'unknown' && valueType !== expectedType
+  );
+
   const pushInvalidSourceProblem = (
     variableId: string,
     variableLabel: string
@@ -133,6 +190,54 @@ export const validateCodingScheme = (
       ]);
     }
   });
+
+  const getSourceValueShape = (
+    sourceId: string | undefined,
+    visitedCodingIds: Set<string>
+  ): CodingValueShape => {
+    if (!sourceId) {
+      return { valueType: 'unknown' };
+    }
+
+    const sourceCoding = codingById.get(sourceId);
+    if (sourceCoding) {
+      return getCodingValueShape(sourceCoding, visitedCodingIds);
+    }
+
+    return getBaseVariableValueShape(baseVarById.get(sourceId));
+  };
+
+  const getCodingValueShape = (
+    coding: VariableCodingData,
+    visitedCodingIds: Set<string> = new Set<string>()
+  ): CodingValueShape => {
+    if (visitedCodingIds.has(coding.id)) {
+      return { valueType: 'unknown' };
+    }
+
+    const nextVisitedCodingIds = new Set(visitedCodingIds);
+    nextVisitedCodingIds.add(coding.id);
+
+    switch (coding.sourceType) {
+      case 'BASE':
+        return getBaseVariableValueShape(baseVarById.get(coding.id));
+      case 'COPY_VALUE':
+        return getSourceValueShape(coding.deriveSources?.[0], nextVisitedCodingIds);
+      case 'CONCAT_CODE':
+        return { valueType: 'string', multiple: false };
+      case 'SUM_CODE':
+      case 'SUM_SCORE':
+      case 'SOLVER':
+        return { valueType: 'numeric', multiple: false };
+      case 'UNIQUE_VALUES':
+        return { valueType: 'boolean', multiple: false };
+      case 'BASE_NO_VALUE':
+        return { valueType: 'other', multiple: false };
+      case 'MANUAL':
+      default:
+        return { valueType: 'unknown' };
+    }
+  };
 
   const isDerivedVariable = (vc: VariableCodingData): boolean => (
     vc.sourceType !== 'BASE' && vc.sourceType !== 'BASE_NO_VALUE'
@@ -209,8 +314,10 @@ export const validateCodingScheme = (
     });
 
   variableCodings.forEach(c => {
+    const varInfo = c.sourceType === 'BASE' ? baseVarById.get(c.id) : undefined;
+    const codingValueShape = getCodingValueShape(c);
+
     if (c.sourceType === 'BASE') {
-      const varInfo = baseVarById.get(c.id);
       if (varInfo?.type === 'no-value') {
         problems.push({
           type: 'INVALID_SOURCE',
@@ -228,8 +335,8 @@ export const validateCodingScheme = (
         });
       }
     } else if (c.sourceType === 'BASE_NO_VALUE') {
-      const varInfo = baseVarById.get(c.id);
-      if (varInfo && varInfo.type !== 'no-value') {
+      const noValueVarInfo = baseVarById.get(c.id);
+      if (noValueVarInfo && noValueVarInfo.type !== 'no-value') {
         problems.push({
           type: 'INVALID_SOURCE',
           breaking: true,
@@ -308,7 +415,7 @@ export const validateCodingScheme = (
             pushRulesetValueArrayPosInvalid(
               c.alias || c.id,
               c.label || '',
-              code.id ? code.id.toString(10) : 'null'
+              getCodeRef(code)
             );
           }
 
@@ -316,7 +423,31 @@ export const validateCodingScheme = (
             pushRulesetValueArrayPosInvalid(
               c.alias || c.id,
               c.label || '',
-              code.id ? code.id.toString(10) : 'null'
+              getCodeRef(code)
+            );
+          }
+
+          if (
+            typeof valueArrayPos !== 'undefined' &&
+            codingValueShape.multiple === false
+          ) {
+            pushRulesetValueArrayPosInvalid(
+              c.alias || c.id,
+              c.label || '',
+              getCodeRef(code)
+            );
+          }
+
+          if (
+            typeof valueArrayPos === 'number' &&
+            codingValueShape.multiple === true &&
+            (codingValueShape.valuePositionLabels?.length ?? 0) > 0 &&
+            valueArrayPos >= (codingValueShape.valuePositionLabels?.length ?? 0)
+          ) {
+            pushRulesetValueArrayPosInvalid(
+              c.alias || c.id,
+              c.label || '',
+              getCodeRef(code)
             );
           }
 
@@ -333,12 +464,45 @@ export const validateCodingScheme = (
               pushRuleParameterMismatch(
                 c.alias || c.id,
                 c.label || '',
-                code.id ? code.id.toString(10) : 'null'
+                getCodeRef(code)
               );
               return;
             }
 
             const params = r.parameters ?? [];
+
+            if (
+              typeof r.fragment !== 'undefined' &&
+              (!c.fragmenting || r.fragment < 0 || !Number.isInteger(r.fragment))
+            ) {
+              pushRuleParameterInvalid(
+                c.alias || c.id,
+                c.label || '',
+                getCodeRef(code)
+              );
+            }
+
+            if (
+              numericRuleMethods.includes(r.method) &&
+              isKnownIncompatibleType(codingValueShape.valueType, 'numeric')
+            ) {
+              pushRuleParameterInvalid(
+                c.alias || c.id,
+                c.label || '',
+                getCodeRef(code)
+              );
+            }
+
+            if (
+              booleanRuleMethods.includes(r.method) &&
+              isKnownIncompatibleType(codingValueShape.valueType, 'boolean')
+            ) {
+              pushRuleParameterInvalid(
+                c.alias || c.id,
+                c.label || '',
+                getCodeRef(code)
+              );
+            }
 
             if (r.method === 'MATCH_REGEX') {
               const patterns = params.flatMap(p => p.split(/\r?\n/));
@@ -350,7 +514,7 @@ export const validateCodingScheme = (
                   pushRuleRegexInvalid(
                     c.alias || c.id,
                     c.label || '',
-                    code.id ? code.id.toString(10) : 'null'
+                    getCodeRef(code)
                   );
                 }
               });
@@ -370,7 +534,7 @@ export const validateCodingScheme = (
                 pushRuleParameterInvalid(
                   c.alias || c.id,
                   c.label || '',
-                  code.id ? code.id.toString(10) : 'null'
+                  getCodeRef(code)
                 );
               }
             }
@@ -385,7 +549,7 @@ export const validateCodingScheme = (
                 pushRuleNumericRangeInvalid(
                   c.alias || c.id,
                   c.label || '',
-                  code.id ? code.id.toString(10) : 'null'
+                  getCodeRef(code)
                 );
               } else {
                 const llNum = Number.parseFloat(ll);
@@ -394,7 +558,7 @@ export const validateCodingScheme = (
                   pushRuleNumericRangeInvalid(
                     c.alias || c.id,
                     c.label || '',
-                    code.id ? code.id.toString(10) : 'null'
+                    getCodeRef(code)
                   );
                 }
               }

--- a/src/validation/validate-coding-scheme.ts
+++ b/src/validation/validate-coding-scheme.ts
@@ -138,11 +138,18 @@ export const validateCodingScheme = (
     return { valueType: 'other', multiple, valuePositionLabels };
   };
 
-  const isKnownIncompatibleType = (
-    valueType: CodingValueType,
-    expectedType: CodingValueType
+  const isKnownIncompatibleNumericRuleType = (
+    valueType: CodingValueType
   ): boolean => (
-    valueType !== 'unknown' && valueType !== expectedType
+    valueType !== 'unknown' &&
+    !['numeric', 'boolean', 'string'].includes(valueType)
+  );
+
+  const isKnownIncompatibleBooleanRuleType = (
+    valueType: CodingValueType
+  ): boolean => (
+    valueType !== 'unknown' &&
+    !['numeric', 'boolean', 'string'].includes(valueType)
   );
 
   const pushInvalidSourceProblem = (
@@ -484,7 +491,7 @@ export const validateCodingScheme = (
 
             if (
               numericRuleMethods.includes(r.method) &&
-              isKnownIncompatibleType(codingValueShape.valueType, 'numeric')
+              isKnownIncompatibleNumericRuleType(codingValueShape.valueType)
             ) {
               pushRuleParameterInvalid(
                 c.alias || c.id,
@@ -495,7 +502,7 @@ export const validateCodingScheme = (
 
             if (
               booleanRuleMethods.includes(r.method) &&
-              isKnownIncompatibleType(codingValueShape.valueType, 'boolean')
+              isKnownIncompatibleBooleanRuleType(codingValueShape.valueType)
             ) {
               pushRuleParameterInvalid(
                 c.alias || c.id,

--- a/src/validation/validate-coding-scheme.ts
+++ b/src/validation/validate-coding-scheme.ts
@@ -480,7 +480,7 @@ export const validateCodingScheme = (
 
             if (
               typeof r.fragment !== 'undefined' &&
-              (!c.fragmenting || r.fragment < 0 || !Number.isInteger(r.fragment))
+              (!c.fragmenting || r.fragment < -1 || !Number.isInteger(r.fragment))
             ) {
               pushRuleParameterInvalid(
                 c.alias || c.id,

--- a/test/unit/coding-scheme-factory.test.ts
+++ b/test/unit/coding-scheme-factory.test.ts
@@ -555,9 +555,42 @@ describe('CodingSchemeFactory', () => {
       ).toBe(true);
     });
 
-    test('detects RULE_PARAMETER_INVALID for numeric rules on non-numeric base variables', () => {
+    test('accepts numeric rules on string base variables', () => {
       const baseVars: VariableInfo[] = [
         { id: 'v1', type: 'string' }
+      ] as unknown as VariableInfo[];
+
+      const coding = CodingFactory.createCodingVariable('v1');
+      coding.codes = <CodeData[]>[
+        {
+          id: 1,
+          score: 1,
+          label: '',
+          type: 'FULL_CREDIT',
+          manualInstruction: '',
+          ruleSetOperatorAnd: false,
+          ruleSets: [
+            {
+              ruleOperatorAnd: false,
+              rules: [{ method: 'NUMERIC_MATCH', parameters: ['1'] }]
+            }
+          ]
+        }
+      ];
+
+      const problems = CodingSchemeFactory.validate(baseVars, [coding]);
+      expect(
+        problems.some(
+          p => p.type === 'RULE_PARAMETER_INVALID' &&
+            p.breaking &&
+            p.code === '1'
+        )
+      ).toBe(false);
+    });
+
+    test('detects RULE_PARAMETER_INVALID for numeric rules on non-scalar base variables', () => {
+      const baseVars: VariableInfo[] = [
+        { id: 'v1', type: 'attachment' }
       ] as unknown as VariableInfo[];
 
       const coding = CodingFactory.createCodingVariable('v1');
@@ -588,9 +621,108 @@ describe('CodingSchemeFactory', () => {
       ).toBe(true);
     });
 
-    test('detects RULE_PARAMETER_INVALID for boolean rules on non-boolean base variables', () => {
+    test('accepts numeric rules on boolean base variables', () => {
+      const baseVars: VariableInfo[] = [
+        { id: 'v1', type: 'boolean' }
+      ] as unknown as VariableInfo[];
+
+      const coding = CodingFactory.createCodingVariable('v1');
+      coding.codes = <CodeData[]>[
+        {
+          id: 1,
+          score: 1,
+          label: '',
+          type: 'FULL_CREDIT',
+          manualInstruction: '',
+          ruleSetOperatorAnd: false,
+          ruleSets: [
+            {
+              ruleOperatorAnd: false,
+              rules: [{ method: 'NUMERIC_MATCH', parameters: ['1'] }]
+            }
+          ]
+        }
+      ];
+
+      const problems = CodingSchemeFactory.validate(baseVars, [coding]);
+      expect(
+        problems.some(
+          p => p.type === 'RULE_PARAMETER_INVALID' &&
+            p.breaking &&
+            p.code === '1'
+        )
+      ).toBe(false);
+    });
+
+    test('accepts boolean rules on numeric base variables', () => {
       const baseVars: VariableInfo[] = [
         { id: 'v1', type: 'number' }
+      ] as unknown as VariableInfo[];
+
+      const coding = CodingFactory.createCodingVariable('v1');
+      coding.codes = <CodeData[]>[
+        {
+          id: 1,
+          score: 1,
+          label: '',
+          type: 'FULL_CREDIT',
+          manualInstruction: '',
+          ruleSetOperatorAnd: false,
+          ruleSets: [
+            {
+              ruleOperatorAnd: false,
+              rules: [{ method: 'IS_TRUE' }]
+            }
+          ]
+        }
+      ];
+
+      const problems = CodingSchemeFactory.validate(baseVars, [coding]);
+      expect(
+        problems.some(
+          p => p.type === 'RULE_PARAMETER_INVALID' &&
+            p.breaking &&
+            p.code === '1'
+        )
+      ).toBe(false);
+    });
+
+    test('accepts boolean rules on string base variables', () => {
+      const baseVars: VariableInfo[] = [
+        { id: 'v1', type: 'string' }
+      ] as unknown as VariableInfo[];
+
+      const coding = CodingFactory.createCodingVariable('v1');
+      coding.codes = <CodeData[]>[
+        {
+          id: 1,
+          score: 1,
+          label: '',
+          type: 'FULL_CREDIT',
+          manualInstruction: '',
+          ruleSetOperatorAnd: false,
+          ruleSets: [
+            {
+              ruleOperatorAnd: false,
+              rules: [{ method: 'IS_TRUE' }]
+            }
+          ]
+        }
+      ];
+
+      const problems = CodingSchemeFactory.validate(baseVars, [coding]);
+      expect(
+        problems.some(
+          p => p.type === 'RULE_PARAMETER_INVALID' &&
+            p.breaking &&
+            p.code === '1'
+        )
+      ).toBe(false);
+    });
+
+    test('detects RULE_PARAMETER_INVALID for boolean rules on non-scalar base variables', () => {
+      const baseVars: VariableInfo[] = [
+        { id: 'v1', type: 'attachment' }
       ] as unknown as VariableInfo[];
 
       const coding = CodingFactory.createCodingVariable('v1');
@@ -621,7 +753,7 @@ describe('CodingSchemeFactory', () => {
       ).toBe(true);
     });
 
-    test('detects RULE_PARAMETER_INVALID for numeric rules on non-numeric derived variables', () => {
+    test('accepts numeric rules on string derived variables', () => {
       const baseVars: VariableInfo[] = [
         { id: 'v1', type: 'string' },
         { id: 'v2', type: 'string' }
@@ -656,10 +788,10 @@ describe('CodingSchemeFactory', () => {
             p.breaking &&
             p.code === '1'
         )
-      ).toBe(true);
+      ).toBe(false);
     });
 
-    test('detects RULE_PARAMETER_INVALID for boolean rules on numeric derived variables', () => {
+    test('accepts boolean rules on numeric derived variables', () => {
       const baseVars: VariableInfo[] = [
         { id: 'v1', type: 'number' },
         { id: 'v2', type: 'number' }
@@ -694,7 +826,7 @@ describe('CodingSchemeFactory', () => {
             p.breaking &&
             p.code === '1'
         )
-      ).toBe(true);
+      ).toBe(false);
     });
 
     test('accepts numeric rules on numeric derived variables', () => {
@@ -735,9 +867,87 @@ describe('CodingSchemeFactory', () => {
       ).toBe(false);
     });
 
-    test('detects RULE_PARAMETER_INVALID when COPY_VALUE inherits a non-numeric source type', () => {
+    test('accepts numeric rules on boolean derived variables', () => {
+      const baseVars: VariableInfo[] = [
+        { id: 'v1', type: 'string' },
+        { id: 'v2', type: 'string' }
+      ] as unknown as VariableInfo[];
+
+      const coding: VariableCodingData = {
+        ...CodingFactory.createCodingVariable('d1'),
+        sourceType: 'UNIQUE_VALUES',
+        deriveSources: ['v1', 'v2'],
+        codes: <CodeData[]>[
+          {
+            id: 1,
+            score: 1,
+            label: '',
+            type: 'FULL_CREDIT',
+            manualInstruction: '',
+            ruleSetOperatorAnd: false,
+            ruleSets: [
+              {
+                ruleOperatorAnd: false,
+                rules: [{ method: 'NUMERIC_MATCH', parameters: ['1'] }]
+              }
+            ]
+          }
+        ]
+      } as VariableCodingData;
+
+      const problems = CodingSchemeFactory.validate(baseVars, [coding]);
+      expect(
+        problems.some(
+          p => p.type === 'RULE_PARAMETER_INVALID' &&
+            p.breaking &&
+            p.code === '1'
+        )
+      ).toBe(false);
+    });
+
+    test('accepts numeric rules when COPY_VALUE inherits a string source type', () => {
       const baseVars: VariableInfo[] = [
         { id: 'v1', type: 'string' }
+      ] as unknown as VariableInfo[];
+
+      const baseCoding = CodingFactory.createCodingVariable('v1');
+      baseCoding.codes = [];
+
+      const coding: VariableCodingData = {
+        ...CodingFactory.createCodingVariable('d1'),
+        sourceType: 'COPY_VALUE',
+        deriveSources: ['v1'],
+        codes: <CodeData[]>[
+          {
+            id: 1,
+            score: 1,
+            label: '',
+            type: 'FULL_CREDIT',
+            manualInstruction: '',
+            ruleSetOperatorAnd: false,
+            ruleSets: [
+              {
+                ruleOperatorAnd: false,
+                rules: [{ method: 'NUMERIC_MATCH', parameters: ['1'] }]
+              }
+            ]
+          }
+        ]
+      } as VariableCodingData;
+
+      const problems = CodingSchemeFactory.validate(baseVars, [baseCoding, coding]);
+      expect(
+        problems.some(
+          p => p.type === 'RULE_PARAMETER_INVALID' &&
+            p.breaking &&
+            p.code === '1'
+        )
+      ).toBe(false);
+    });
+
+    test('detects RULE_PARAMETER_INVALID when COPY_VALUE inherits a non-scalar source type', () => {
+      const baseVars: VariableInfo[] = [
+        { id: 'v1', type: 'attachment' }
       ] as unknown as VariableInfo[];
 
       const baseCoding = CodingFactory.createCodingVariable('v1');

--- a/test/unit/coding-scheme-factory.test.ts
+++ b/test/unit/coding-scheme-factory.test.ts
@@ -555,6 +555,327 @@ describe('CodingSchemeFactory', () => {
       ).toBe(true);
     });
 
+    test('detects RULE_PARAMETER_INVALID for numeric rules on non-numeric base variables', () => {
+      const baseVars: VariableInfo[] = [
+        { id: 'v1', type: 'string' }
+      ] as unknown as VariableInfo[];
+
+      const coding = CodingFactory.createCodingVariable('v1');
+      coding.codes = <CodeData[]>[
+        {
+          id: 1,
+          score: 1,
+          label: '',
+          type: 'FULL_CREDIT',
+          manualInstruction: '',
+          ruleSetOperatorAnd: false,
+          ruleSets: [
+            {
+              ruleOperatorAnd: false,
+              rules: [{ method: 'NUMERIC_MATCH', parameters: ['1'] }]
+            }
+          ]
+        }
+      ];
+
+      const problems = CodingSchemeFactory.validate(baseVars, [coding]);
+      expect(
+        problems.some(
+          p => p.type === 'RULE_PARAMETER_INVALID' &&
+            p.breaking &&
+            p.code === '1'
+        )
+      ).toBe(true);
+    });
+
+    test('detects RULE_PARAMETER_INVALID for boolean rules on non-boolean base variables', () => {
+      const baseVars: VariableInfo[] = [
+        { id: 'v1', type: 'number' }
+      ] as unknown as VariableInfo[];
+
+      const coding = CodingFactory.createCodingVariable('v1');
+      coding.codes = <CodeData[]>[
+        {
+          id: 1,
+          score: 1,
+          label: '',
+          type: 'FULL_CREDIT',
+          manualInstruction: '',
+          ruleSetOperatorAnd: false,
+          ruleSets: [
+            {
+              ruleOperatorAnd: false,
+              rules: [{ method: 'IS_TRUE' }]
+            }
+          ]
+        }
+      ];
+
+      const problems = CodingSchemeFactory.validate(baseVars, [coding]);
+      expect(
+        problems.some(
+          p => p.type === 'RULE_PARAMETER_INVALID' &&
+            p.breaking &&
+            p.code === '1'
+        )
+      ).toBe(true);
+    });
+
+    test('detects RULE_PARAMETER_INVALID for numeric rules on non-numeric derived variables', () => {
+      const baseVars: VariableInfo[] = [
+        { id: 'v1', type: 'string' },
+        { id: 'v2', type: 'string' }
+      ] as unknown as VariableInfo[];
+
+      const coding: VariableCodingData = {
+        ...CodingFactory.createCodingVariable('d1'),
+        sourceType: 'CONCAT_CODE',
+        deriveSources: ['v1', 'v2'],
+        codes: <CodeData[]>[
+          {
+            id: 1,
+            score: 1,
+            label: '',
+            type: 'FULL_CREDIT',
+            manualInstruction: '',
+            ruleSetOperatorAnd: false,
+            ruleSets: [
+              {
+                ruleOperatorAnd: false,
+                rules: [{ method: 'NUMERIC_MATCH', parameters: ['1'] }]
+              }
+            ]
+          }
+        ]
+      } as VariableCodingData;
+
+      const problems = CodingSchemeFactory.validate(baseVars, [coding]);
+      expect(
+        problems.some(
+          p => p.type === 'RULE_PARAMETER_INVALID' &&
+            p.breaking &&
+            p.code === '1'
+        )
+      ).toBe(true);
+    });
+
+    test('detects RULE_PARAMETER_INVALID for boolean rules on numeric derived variables', () => {
+      const baseVars: VariableInfo[] = [
+        { id: 'v1', type: 'number' },
+        { id: 'v2', type: 'number' }
+      ] as unknown as VariableInfo[];
+
+      const coding: VariableCodingData = {
+        ...CodingFactory.createCodingVariable('d1'),
+        sourceType: 'SUM_SCORE',
+        deriveSources: ['v1', 'v2'],
+        codes: <CodeData[]>[
+          {
+            id: 1,
+            score: 1,
+            label: '',
+            type: 'FULL_CREDIT',
+            manualInstruction: '',
+            ruleSetOperatorAnd: false,
+            ruleSets: [
+              {
+                ruleOperatorAnd: false,
+                rules: [{ method: 'IS_TRUE' }]
+              }
+            ]
+          }
+        ]
+      } as VariableCodingData;
+
+      const problems = CodingSchemeFactory.validate(baseVars, [coding]);
+      expect(
+        problems.some(
+          p => p.type === 'RULE_PARAMETER_INVALID' &&
+            p.breaking &&
+            p.code === '1'
+        )
+      ).toBe(true);
+    });
+
+    test('accepts numeric rules on numeric derived variables', () => {
+      const baseVars: VariableInfo[] = [
+        { id: 'v1', type: 'number' },
+        { id: 'v2', type: 'number' }
+      ] as unknown as VariableInfo[];
+
+      const coding: VariableCodingData = {
+        ...CodingFactory.createCodingVariable('d1'),
+        sourceType: 'SUM_SCORE',
+        deriveSources: ['v1', 'v2'],
+        codes: <CodeData[]>[
+          {
+            id: 1,
+            score: 1,
+            label: '',
+            type: 'FULL_CREDIT',
+            manualInstruction: '',
+            ruleSetOperatorAnd: false,
+            ruleSets: [
+              {
+                ruleOperatorAnd: false,
+                rules: [{ method: 'NUMERIC_MATCH', parameters: ['1'] }]
+              }
+            ]
+          }
+        ]
+      } as VariableCodingData;
+
+      const problems = CodingSchemeFactory.validate(baseVars, [coding]);
+      expect(
+        problems.some(
+          p => p.type === 'RULE_PARAMETER_INVALID' &&
+            p.breaking &&
+            p.code === '1'
+        )
+      ).toBe(false);
+    });
+
+    test('detects RULE_PARAMETER_INVALID when COPY_VALUE inherits a non-numeric source type', () => {
+      const baseVars: VariableInfo[] = [
+        { id: 'v1', type: 'string' }
+      ] as unknown as VariableInfo[];
+
+      const baseCoding = CodingFactory.createCodingVariable('v1');
+      baseCoding.codes = [];
+
+      const coding: VariableCodingData = {
+        ...CodingFactory.createCodingVariable('d1'),
+        sourceType: 'COPY_VALUE',
+        deriveSources: ['v1'],
+        codes: <CodeData[]>[
+          {
+            id: 1,
+            score: 1,
+            label: '',
+            type: 'FULL_CREDIT',
+            manualInstruction: '',
+            ruleSetOperatorAnd: false,
+            ruleSets: [
+              {
+                ruleOperatorAnd: false,
+                rules: [{ method: 'NUMERIC_MATCH', parameters: ['1'] }]
+              }
+            ]
+          }
+        ]
+      } as VariableCodingData;
+
+      const problems = CodingSchemeFactory.validate(baseVars, [baseCoding, coding]);
+      expect(
+        problems.some(
+          p => p.type === 'RULE_PARAMETER_INVALID' &&
+            p.breaking &&
+            p.code === '1'
+        )
+      ).toBe(true);
+    });
+
+    test('detects RULESET_VALUE_ARRAY_POS_INVALID for array references on single-value variables', () => {
+      const baseVars: VariableInfo[] = [
+        { id: 'v1', multiple: false }
+      ] as unknown as VariableInfo[];
+
+      const coding = CodingFactory.createCodingVariable('v1');
+      coding.codes = <CodeData[]>[
+        {
+          id: 1,
+          score: 1,
+          label: '',
+          type: 'FULL_CREDIT',
+          manualInstruction: '',
+          ruleSetOperatorAnd: false,
+          ruleSets: [
+            {
+              valueArrayPos: 0,
+              ruleOperatorAnd: false,
+              rules: [{ method: 'MATCH', parameters: ['A'] }]
+            }
+          ]
+        }
+      ];
+
+      const problems = CodingSchemeFactory.validate(baseVars, [coding]);
+      expect(
+        problems.some(
+          p => p.type === 'RULESET_VALUE_ARRAY_POS_INVALID' &&
+            p.breaking &&
+            p.code === '1'
+        )
+      ).toBe(true);
+    });
+
+    test('detects RULESET_VALUE_ARRAY_POS_INVALID for array positions outside known labels', () => {
+      const baseVars: VariableInfo[] = [
+        { id: 'v1', multiple: true, valuePositionLabels: ['first'] }
+      ] as unknown as VariableInfo[];
+
+      const coding = CodingFactory.createCodingVariable('v1');
+      coding.codes = <CodeData[]>[
+        {
+          id: 1,
+          score: 1,
+          label: '',
+          type: 'FULL_CREDIT',
+          manualInstruction: '',
+          ruleSetOperatorAnd: false,
+          ruleSets: [
+            {
+              valueArrayPos: 1,
+              ruleOperatorAnd: false,
+              rules: [{ method: 'MATCH', parameters: ['A'] }]
+            }
+          ]
+        }
+      ];
+
+      const problems = CodingSchemeFactory.validate(baseVars, [coding]);
+      expect(
+        problems.some(
+          p => p.type === 'RULESET_VALUE_ARRAY_POS_INVALID' &&
+            p.breaking &&
+            p.code === '1'
+        )
+      ).toBe(true);
+    });
+
+    test('detects RULE_PARAMETER_INVALID for fragment references without fragmenting', () => {
+      const baseVars: VariableInfo[] = [
+        { id: 'v1', type: 'string' }
+      ] as unknown as VariableInfo[];
+
+      const coding = CodingFactory.createCodingVariable('v1');
+      coding.codes = <CodeData[]>[
+        {
+          id: 1,
+          score: 1,
+          label: '',
+          type: 'FULL_CREDIT',
+          manualInstruction: '',
+          ruleSetOperatorAnd: false,
+          ruleSets: [
+            {
+              ruleOperatorAnd: false,
+              rules: [{ method: 'MATCH', parameters: ['A'], fragment: 0 }]
+            }
+          ]
+        }
+      ];
+
+      const problems = CodingSchemeFactory.validate(baseVars, [coding]);
+      expect(
+        problems.some(
+          p => p.type === 'RULE_PARAMETER_INVALID' &&
+            p.breaking &&
+            p.code === '1'
+        )
+      ).toBe(true);
+    });
+
     test('detects INVALID_SOURCE for duplicate base variable ids in var info list', () => {
       const baseVars: VariableInfo[] = [
         { id: 'v1' },

--- a/test/unit/coding-scheme-factory.test.ts
+++ b/test/unit/coding-scheme-factory.test.ts
@@ -1086,6 +1086,40 @@ describe('CodingSchemeFactory', () => {
       ).toBe(true);
     });
 
+    test('accepts fragment -1 as any fragment when fragmenting is configured', () => {
+      const baseVars: VariableInfo[] = [
+        { id: 'v1', type: 'string' }
+      ] as unknown as VariableInfo[];
+
+      const coding = CodingFactory.createCodingVariable('v1');
+      coding.fragmenting = '([0-9]+)-([A-Z]+)';
+      coding.codes = <CodeData[]>[
+        {
+          id: 1,
+          score: 1,
+          label: '',
+          type: 'FULL_CREDIT',
+          manualInstruction: '',
+          ruleSetOperatorAnd: false,
+          ruleSets: [
+            {
+              ruleOperatorAnd: false,
+              rules: [{ method: 'MATCH', parameters: ['A'], fragment: -1 }]
+            }
+          ]
+        }
+      ];
+
+      const problems = CodingSchemeFactory.validate(baseVars, [coding]);
+      expect(
+        problems.some(
+          p => p.type === 'RULE_PARAMETER_INVALID' &&
+            p.breaking &&
+            p.code === '1'
+        )
+      ).toBe(false);
+    });
+
     test('detects INVALID_SOURCE for duplicate base variable ids in var info list', () => {
       const baseVars: VariableInfo[] = [
         { id: 'v1' },


### PR DESCRIPTION
## Summary
- Add conservative value-shape inference for coding scheme validation.
- Validate numeric and boolean rules against known base and derived variable value types.
- Extend valueArrayPos validation beyond base variables when scalar derived outputs are known.
- Add regression coverage for derived variables and COPY_VALUE inherited source types.

## Validation
- npm test -- test/unit/coding-scheme-factory.test.ts --runInBand
- npm run lint -- src/validation/validate-coding-scheme.ts test/unit/coding-scheme-factory.test.ts
- npx tsc --noEmit
- npm test -- --runInBand