### PR TITLE
Prevent empty numeric matches for zero

### DIFF
--- a/src/rule-engine/scalar-evaluator.ts
+++ b/src/rule-engine/scalar-evaluator.ts
@@ -52,6 +52,10 @@ function findNumericValue(
   value: ResponseValueSingleType,
   parameters: string[] = []
 ): boolean {
+  if (value === null || value === '') {
+    return false;
+  }
+
   const allCompareValues = parameters
     .flatMap(p => p.split(/\r?\n/))
     .map(s => getValueAsNumber(s));

--- a/test/coding/rules/numeric-match/01_outcome.json
+++ b/test/coding/rules/numeric-match/01_outcome.json
@@ -24,12 +24,12 @@
     "id": "b4",
     "value": null,
     "status": "CODING_COMPLETE",
-    "code": 1,
-    "score": 1
+    "code": 0,
+    "score": 0
   },
   {
     "id": "d1",
-    "value": 3,
+    "value": 2,
     "status": "CODING_COMPLETE",
     "code": 0,
     "score": 0

--- a/test/unit/coding-scheme-factory.test.ts
+++ b/test/unit/coding-scheme-factory.test.ts
@@ -1194,6 +1194,93 @@ describe('CodingSchemeFactory', () => {
   });
 
   describe('code', () => {
+    test('does not score displayed empty responses as NUMERIC_MATCH zero', () => {
+      const source = CodingFactory.createCodingVariable('v1');
+      source.sourceParameters = {
+        processing: [
+          'TAKE_DISPLAYED_AS_VALUE_CHANGED',
+          'TAKE_EMPTY_AS_VALID'
+        ]
+      };
+      source.codes = <CodeData[]>[
+        {
+          id: 1,
+          score: 1,
+          label: '',
+          type: 'FULL_CREDIT',
+          manualInstruction: '',
+          ruleSetOperatorAnd: false,
+          ruleSets: [
+            {
+              ruleOperatorAnd: true,
+              rules: [{ method: 'NUMERIC_MATCH', parameters: ['0'] }]
+            }
+          ]
+        },
+        {
+          id: 0,
+          score: 0,
+          label: '',
+          type: 'RESIDUAL_AUTO',
+          manualInstruction: '',
+          ruleSetOperatorAnd: false,
+          ruleSets: []
+        }
+      ];
+
+      const coded = CodingSchemeFactory.code(
+        [{ id: 'v1', value: '', status: 'DISPLAYED' } as Response],
+        [source]
+      );
+
+      const response = coded.find(r => r.id === 'v1');
+      expect(response?.status).toBe('CODING_COMPLETE');
+      expect(response?.code).toBe(0);
+      expect(response?.score).toBe(0);
+    });
+
+    test('does not score null responses as NUMERIC_MATCH zero', () => {
+      const source = CodingFactory.createCodingVariable('v1');
+      source.sourceParameters = {
+        processing: ['TAKE_EMPTY_AS_VALID']
+      };
+      source.codes = <CodeData[]>[
+        {
+          id: 1,
+          score: 1,
+          label: '',
+          type: 'FULL_CREDIT',
+          manualInstruction: '',
+          ruleSetOperatorAnd: false,
+          ruleSets: [
+            {
+              ruleOperatorAnd: true,
+              rules: [{ method: 'NUMERIC_MATCH', parameters: ['0'] }]
+            }
+          ]
+        },
+        {
+          id: 0,
+          score: 0,
+          label: '',
+          type: 'RESIDUAL_AUTO',
+          manualInstruction: '',
+          ruleSetOperatorAnd: false,
+          ruleSets: []
+        }
+      ];
+
+      const coded = CodingSchemeFactory.code(
+        [{ id: 'v1', value: null, status: 'VALUE_CHANGED' } as Response],
+        [source]
+      );
+
+      const response = coded.find(r => r.id === 'v1');
+      expect(response?.status).toBe('CODING_COMPLETE');
+      expect(response?.code).toBe(0);
+      expect(response?.score).toBe(0);
+    });
+
     test('marks empty string as INVALID for BASE unless TAKE_EMPTY_AS_VALID is set', () => {
       const v1 = CodingFactory.createCodingVariable('v1');
       v1.sourceParameters = v1.sourceParameters || { processing: [] };

--- a/test/unit/rule-engine.test.ts
+++ b/test/unit/rule-engine.test.ts
@@ -56,6 +56,24 @@ describe('rule-engine', () => {
         expected: true
       },
       {
+        title: 'NUMERIC_MATCH does not treat null as numeric zero',
+        value: null,
+        rule: { method: 'NUMERIC_MATCH', parameters: ['0'] } as CodingRule,
+        expected: false
+      },
+      {
+        title: 'NUMERIC_MATCH does not treat empty string as numeric zero',
+        value: '',
+        rule: { method: 'NUMERIC_MATCH', parameters: ['0'] } as CodingRule,
+        expected: false
+      },
+      {
+        title: 'NUMERIC_MATCH still matches explicit numeric zero',
+        value: '00',
+        rule: { method: 'NUMERIC_MATCH', parameters: ['0'] } as CodingRule,
+        expected: true
+      },
+      {
         title: 'NUMERIC_RANGE is lower-exclusive, upper-inclusive',
         value: '5',
         rule: {


### PR DESCRIPTION
## Summary

- Prevent scalar `NUMERIC_MATCH` from treating `null` and empty string responses as numeric zero.
- Keep explicit numeric zero values, including values such as `00`, matching `0`.
- Add regression coverage for direct rule evaluation and the reported coding flow with empty responses marked as valid.

## Context

Refs iqb-berlin/coding-components#201

## Validation

- `npm test -- --runInBand`
- `npm run lint`
- `npx tsc --noEmit`
- `git diff --check`
