### PR TITLE
Guard invalid derive source types

### DIFF
--- a/src/derive/derive-value.ts
+++ b/src/derive/derive-value.ts
@@ -659,6 +659,8 @@ export const deriveValue = (
     SOLVER: handleSolver
   };
 
-  const handler = handlers[coding.sourceType];
+  const handler = Object.prototype.hasOwnProperty.call(handlers, coding.sourceType) ?
+    handlers[coding.sourceType] :
+    undefined;
   return handler ? handler(ctx) : deriveErrorResponse(coding, subformSource);
 };

--- a/test/unit/derive-value.test.ts
+++ b/test/unit/derive-value.test.ts
@@ -778,4 +778,23 @@ describe('deriveValue', () => {
     expect(result.status).toBe('CODING_INCOMPLETE');
     expect(result.value).toBeNull();
   });
+
+  test('returns DERIVE_ERROR if sourceType is invalid', () => {
+    const coding: VariableCodingData = {
+      ...CodingFactory.createCodingVariable('d'),
+      sourceType: 'toString' as unknown as VariableCodingData['sourceType'],
+      deriveSources: ['v1'],
+      codes: []
+    } as VariableCodingData;
+
+    const r1: Response = {
+      id: 'v1',
+      value: 1,
+      status: 'VALUE_CHANGED'
+    } as Response;
+
+    const result = deriveValue([coding], coding, [r1]);
+    expect(result.status).toBe('DERIVE_ERROR');
+    expect(result.value).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary

Adds an own-property guard before dispatching derive source type handlers, so invalid values such as `toString` cannot resolve through `Object.prototype`.

## Why

`deriveValue` previously indexed the handler map directly with `coding.sourceType`. For malformed input, inherited object properties could be treated as truthy handler values instead of falling back to a controlled `DERIVE_ERROR` response.

## Validation

- `npm test -- --runInBand test/unit/derive-value.test.ts`
- `npm test -- --runInBand`
- `npm run lint`