### PR TITLE
Add alias ID collision diagnostics

### DIFF
--- a/src/coding-interfaces.ts
+++ b/src/coding-interfaces.ts
@@ -1,11 +1,17 @@
 import { CodingSchemeProblemType } from '@iqbspecs/coding-scheme/coding-scheme.interface';
 
+export type CodingSchemeProblemReason = 'ALIAS_ID_COLLISION';
+
 export interface CodingSchemeProblem {
   type: CodingSchemeProblemType,
   breaking: boolean,
   variableId: string,
   variableLabel: string,
-  code?: string
+  code?: string,
+  reason?: CodingSchemeProblemReason,
+  alias?: string,
+  aliasVariableId?: string,
+  collidingVariableId?: string
 }
 
 export interface CodeAsText {

--- a/src/validation/validate-coding-scheme.ts
+++ b/src/validation/validate-coding-scheme.ts
@@ -14,6 +14,13 @@ type CodingValueShape = {
   valuePositionLabels?: string[];
 };
 
+type InvalidSourceProblemDetails = {
+  reason?: CodingSchemeProblem['reason'];
+  alias?: string;
+  aliasVariableId?: string;
+  collidingVariableId?: string;
+};
+
 export const validateCodingScheme = (
   baseVariables: VariableInfo[],
   variableCodings: VariableCodingData[]
@@ -154,13 +161,25 @@ export const validateCodingScheme = (
 
   const pushInvalidSourceProblem = (
     variableId: string,
-    variableLabel: string
+    variableLabel: string,
+    details: InvalidSourceProblemDetails = {}
   ) => {
     problems.push({
       type: 'INVALID_SOURCE',
       breaking: true,
       variableId,
-      variableLabel
+      variableLabel,
+      ...details
+    });
+  };
+
+  const pushAliasIdCollisionProblem = (vc: VariableCodingData) => {
+    if (!vc.alias) return;
+    pushInvalidSourceProblem(vc.alias, vc.label || '', {
+      reason: 'ALIAS_ID_COLLISION',
+      alias: vc.alias,
+      aliasVariableId: vc.id,
+      collidingVariableId: vc.alias
     });
   };
 
@@ -298,7 +317,7 @@ export const validateCodingScheme = (
       vc.alias !== vc.id &&
       !isDerivedShadowingItsBaseSource(vc)
     ) {
-      pushInvalidSourceProblem(vc.alias || vc.id, vc.label || '');
+      pushAliasIdCollisionProblem(vc);
     }
   });
 

--- a/test/unit/coding-scheme-factory.test.ts
+++ b/test/unit/coding-scheme-factory.test.ts
@@ -398,6 +398,17 @@ describe('CodingSchemeFactory', () => {
       expect(
         problems.some(p => p.type === 'INVALID_SOURCE' && p.breaking)
       ).toBe(true);
+      expect(
+        problems.find(p => p.reason === 'ALIAS_ID_COLLISION')
+      ).toMatchObject({
+        type: 'INVALID_SOURCE',
+        breaking: true,
+        variableId: 'v2',
+        variableLabel: '',
+        alias: 'v2',
+        aliasVariableId: 'v1',
+        collidingVariableId: 'v2'
+      });
     });
 
     test('allows a derived variable to shadow its base source id by alias', () => {


### PR DESCRIPTION
## Summary

- keep alias/ID collisions reported as `INVALID_SOURCE` for compatibility
- add optional diagnostic metadata to `CodingSchemeProblem`
- expose `reason: 'ALIAS_ID_COLLISION'` with the alias, alias owner, and colliding variable id
- cover the diagnostic metadata with a regression test

## Root Cause

Alias/ID collisions were already rejected, but they were indistinguishable from other `INVALID_SOURCE` cases. Host applications could not tell whether a source was genuinely invalid or whether the problem was a name collision between a variable alias and another variable id.

## Validation

- `npm test -- --runInBand`
- `npm run lint`
- `npx tsc --noEmit`
- `git diff --check`
