### PR TITLE
Allow alias and ID namespace overlaps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@iqb/responses",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@iqb/responses",
-      "version": "5.2.0",
+      "version": "5.2.1",
       "license": "MIT",
       "dependencies": {
         "@iqbspecs/coding-scheme": "^3.4.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@iqb/responses",
   "author": "IQB - Institut zur Qualitätsentwicklung im Bildungswesen",
   "license": "MIT",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "Automatic coding.",
   "scripts": {
     "test": "jest",

--- a/package_npm.json
+++ b/package_npm.json
@@ -1,6 +1,6 @@
 {
   "name": "@iqb/responses",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "author": "IQB - Institut zur Qualitätsentwicklung im Bildungswesen",
   "license": "CC0 1.0",
   "description": "Automatic coding.",

--- a/src/validation/validate-coding-scheme.ts
+++ b/src/validation/validate-coding-scheme.ts
@@ -179,12 +179,10 @@ export const validateCodingScheme = (
 
   const codingIdCounts = new Map<string, number>();
   const codingAliasCounts = new Map<string, number>();
-  const codingIds = new Set<string>();
   const codingById = new Map<string, VariableCodingData>();
   const codingsByAlias = new Map<string, VariableCodingData[]>();
   variableCodings.forEach(vc => {
     codingIdCounts.set(vc.id, (codingIdCounts.get(vc.id) ?? 0) + 1);
-    codingIds.add(vc.id);
     codingById.set(vc.id, vc);
     if (vc.alias) {
       codingAliasCounts.set(
@@ -289,14 +287,6 @@ export const validateCodingScheme = (
       vc.alias &&
       (codingAliasCounts.get(vc.alias) ?? 0) > 1 &&
       !isAllowedAliasShadowingGroup(vc.alias)
-    ) {
-      pushInvalidSourceProblem(vc.alias || vc.id, vc.label || '');
-    }
-    if (
-      vc.alias &&
-      codingIds.has(vc.alias) &&
-      vc.alias !== vc.id &&
-      !isDerivedShadowingItsBaseSource(vc)
     ) {
       pushInvalidSourceProblem(vc.alias || vc.id, vc.label || '');
     }

--- a/src/validation/validate-coding-scheme.ts
+++ b/src/validation/validate-coding-scheme.ts
@@ -279,6 +279,24 @@ export const validateCodingScheme = (
     );
   };
 
+  const hasAliasCollisionWithPublicIdentifier = (
+    vc: VariableCodingData
+  ): boolean => {
+    if (!vc.alias || vc.alias === vc.id) {
+      return false;
+    }
+
+    const codingWithMatchingId = codingById.get(vc.alias);
+    if (codingWithMatchingId?.sourceType === 'BASE_NO_VALUE') {
+      return false;
+    }
+
+    return Boolean(
+      codingWithMatchingId &&
+      (codingWithMatchingId.alias || codingWithMatchingId.id) === vc.alias
+    );
+  };
+
   variableCodings.forEach(vc => {
     if ((codingIdCounts.get(vc.id) ?? 0) > 1) {
       pushInvalidSourceProblem(vc.alias || vc.id, vc.label || '');
@@ -287,6 +305,12 @@ export const validateCodingScheme = (
       vc.alias &&
       (codingAliasCounts.get(vc.alias) ?? 0) > 1 &&
       !isAllowedAliasShadowingGroup(vc.alias)
+    ) {
+      pushInvalidSourceProblem(vc.alias || vc.id, vc.label || '');
+    }
+    if (
+      hasAliasCollisionWithPublicIdentifier(vc) &&
+      !isDerivedShadowingItsBaseSource(vc)
     ) {
       pushInvalidSourceProblem(vc.alias || vc.id, vc.label || '');
     }

--- a/test/unit/coding-scheme-factory.test.ts
+++ b/test/unit/coding-scheme-factory.test.ts
@@ -386,18 +386,24 @@ describe('CodingSchemeFactory', () => {
       ).toBe(true);
     });
 
-    test('detects INVALID_SOURCE when an alias collides with another variable id', () => {
-      const baseVars: VariableInfo[] = [] as unknown as VariableInfo[];
+    test('allows a unique alias to match another variable id', () => {
+      const baseVars: VariableInfo[] = [
+        { id: '04', alias: '02', type: 'string' },
+        { id: '02', alias: '05', type: 'string' }
+      ] as unknown as VariableInfo[];
       const v1: VariableCodingData = {
-        ...CodingFactory.createCodingVariable('v1'),
-        alias: 'v2'
+        ...CodingFactory.createCodingVariable('04'),
+        alias: '02'
       } as VariableCodingData;
-      const v2 = CodingFactory.createCodingVariable('v2');
+      const v2: VariableCodingData = {
+        ...CodingFactory.createCodingVariable('02'),
+        alias: '05'
+      } as VariableCodingData;
 
       const problems = CodingSchemeFactory.validate(baseVars, [v1, v2]);
       expect(
         problems.some(p => p.type === 'INVALID_SOURCE' && p.breaking)
-      ).toBe(true);
+      ).toBe(false);
     });
 
     test('allows a derived variable to shadow its base source id by alias', () => {
@@ -1549,6 +1555,49 @@ describe('CodingSchemeFactory', () => {
       );
 
       expect(coded[0].id).toBe('ALIAS_1');
+    });
+
+    test('prefers public aliases while derived sources keep using technical ids', () => {
+      const alias02: VariableCodingData = {
+        ...CodingFactory.createCodingVariable('04'),
+        alias: '02',
+        codes: []
+      } as VariableCodingData;
+      const technical02: VariableCodingData = {
+        ...CodingFactory.createCodingVariable('02'),
+        alias: '05',
+        codes: [{
+          id: 1,
+          score: 1,
+          label: '',
+          type: 'FULL_CREDIT',
+          manualInstruction: '',
+          ruleSetOperatorAnd: false,
+          ruleSets: [{
+            ruleOperatorAnd: false,
+            rules: [{ method: 'MATCH', parameters: ['technical-02'] }]
+          }]
+        }]
+      } as VariableCodingData;
+      const copiedTechnical02: VariableCodingData = {
+        ...CodingFactory.createCodingVariable('copy_02'),
+        alias: 'COPY_02',
+        sourceType: 'COPY_VALUE',
+        deriveSources: ['02'],
+        codes: []
+      } as VariableCodingData;
+
+      const coded = CodingSchemeFactory.code(
+        [
+          { id: '02', value: 'public-02', status: 'VALUE_CHANGED' } as Response,
+          { id: '05', value: 'technical-02', status: 'VALUE_CHANGED' } as Response
+        ],
+        [alias02, technical02, copiedTechnical02]
+      );
+
+      expect(coded.find(r => r.id === '02')?.value).toBe('public-02');
+      expect(coded.find(r => r.id === '05')?.value).toBe('technical-02');
+      expect(coded.find(r => r.id === 'COPY_02')?.value).toBe('technical-02');
     });
 
     test('codes derived alias shadowing as a single external variable', () => {

--- a/test/unit/coding-scheme-factory.test.ts
+++ b/test/unit/coding-scheme-factory.test.ts
@@ -406,6 +406,53 @@ describe('CodingSchemeFactory', () => {
       ).toBe(false);
     });
 
+    test('detects INVALID_SOURCE when an alias collides with a fallback public id', () => {
+      const baseVars: VariableInfo[] = [
+        { id: '02', type: 'string' },
+        { id: '04', type: 'string' }
+      ] as unknown as VariableInfo[];
+      const technical02 = CodingFactory.createCodingVariable('02');
+      delete technical02.alias;
+      const public02: VariableCodingData = {
+        ...CodingFactory.createCodingVariable('04'),
+        alias: '02'
+      } as VariableCodingData;
+
+      const problems = CodingSchemeFactory.validate(
+        baseVars,
+        [technical02, public02]
+      );
+
+      expect(
+        problems.some(p => p.type === 'INVALID_SOURCE' && p.breaking)
+      ).toBe(true);
+    });
+
+    test('allows an alias to match a BASE_NO_VALUE technical id', () => {
+      const baseVars: VariableInfo[] = [
+        { id: '02', type: 'no-value' },
+        { id: '04', type: 'string' }
+      ] as unknown as VariableInfo[];
+      const technical02: VariableCodingData = {
+        ...CodingFactory.createCodingVariable('02'),
+        sourceType: 'BASE_NO_VALUE'
+      } as VariableCodingData;
+      delete technical02.alias;
+      const public02: VariableCodingData = {
+        ...CodingFactory.createCodingVariable('04'),
+        alias: '02'
+      } as VariableCodingData;
+
+      const problems = CodingSchemeFactory.validate(
+        baseVars,
+        [technical02, public02]
+      );
+
+      expect(
+        problems.some(p => p.type === 'INVALID_SOURCE' && p.breaking)
+      ).toBe(false);
+    });
+
     test('allows a derived variable to shadow its base source id by alias', () => {
       const baseVars: VariableInfo[] = [
         { id: '01', type: 'string' }


### PR DESCRIPTION
## Summary

- allow a unique public alias to equal another variable technical ID
- keep duplicate IDs, duplicate aliases, invalid identifiers, and missing technical derive sources as errors
- preserve alias-based public response mapping and ID-based internal derivation references
- prepare the 5.2.1 patch release

## Root cause

Validation treated the public alias namespace and the internal technical-ID namespace as one shared namespace. This rejected otherwise unambiguous public result mappings.

## Validation

- `npm test -- --runInBand` — 287 tests passed
- `npm run lint`
- `npm run prepare_publish`
- package dry-run from `dist/`