### PR TITLE
Document 5.2 releases

### DIFF
--- a/CODING_PROCESS.md
+++ b/CODING_PROCESS.md
@@ -643,13 +643,9 @@ console.log('Required base variables:', required);
 
 ## Version History
 
-### Version 5.0 (Current)
-- Comprehensive refactoring and modularization
-- Improved validation with detailed error reporting
-- Robust error handling for edge cases
-- Performance improvements with Map-based lookups
-- Extensive unit test coverage
-- CI/CD with GitHub Actions and Dependabot
+### Version 5.2.1 (Current)
+- Public aliases and technical IDs may overlap when the resulting external identifiers remain unambiguous.
+- Invalid or unexpected derivation `sourceType` values are handled as `DERIVE_ERROR` instead of resolving inherited object properties as handlers.
 
 ### Previous Versions
 See [README.md](./README.md) for complete version history.

--- a/README.md
+++ b/README.md
@@ -193,6 +193,11 @@ Status strings used by this package include (among others) `VALUE_CHANGED`, `COD
 
 ## Versionsänderungen npm-package `@iqb/responses`
 
+### 5.2.1
+- Ein eindeutiger öffentlicher Alias darf der technischen ID einer anderen Variable entsprechen, sofern deren öffentlicher Bezeichner abweicht. Responses bleiben extern aliasbasiert, während `deriveSources` weiterhin technische IDs referenzieren.
+- Doppelte IDs, doppelte Aliasse und echte öffentliche Kollisionen bleiben ungültig.
+- Unerwartete `sourceType`-Werte führen kontrolliert zu `DERIVE_ERROR`, statt geerbte Object-Properties als Handler aufzulösen.
+
 ### 5.2
 - SOLVER-Ausdrücke können jetzt Fragmente aus Quellvariablen referenzieren, z. B. `${VAR[0]}`.
 - SOLVER-Placeholders unterstützen Policies für leere/fehlende und nicht-numerische Werte, z. B. `${VAR:0}`, `${VAR:INC}` oder `${VAR:0:INC}`.


### PR DESCRIPTION
## Zusammenfassung

- Ergänzt die Versionsnotizen für 5.2.1 im README.
- Aktualisiert die aktuelle Version in `CODING_PROCESS.md` auf 5.2.1.

## Warum

Die GitHub-Releases für 5.2.0 und 5.2.1 wurden nachträglich ergänzt; die Repository-Dokumentation soll die aktuellen Verhaltensänderungen widerspiegeln.

## Auswirkungen

Nur Dokumentation, keine Änderung an der öffentlichen API oder dem npm-Paket.

## Validierung

- `git diff --check`