### PR TITLE
Accept activated no-value variables as valid base sources

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@iqb/responses",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@iqb/responses",
-      "version": "5.2.1",
+      "version": "5.2.2",
       "license": "MIT",
       "dependencies": {
         "@iqbspecs/coding-scheme": "^3.4.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@iqb/responses",
   "author": "IQB - Institut zur Qualitätsentwicklung im Bildungswesen",
   "license": "MIT",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "description": "Automatic coding.",
   "scripts": {
     "test": "jest",

--- a/package_npm.json
+++ b/package_npm.json
@@ -1,6 +1,6 @@
 {
   "name": "@iqb/responses",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "author": "IQB - Institut zur Qualitätsentwicklung im Bildungswesen",
   "license": "CC0 1.0",
   "description": "Automatic coding.",

--- a/src/validation/validate-coding-scheme.ts
+++ b/src/validation/validate-coding-scheme.ts
@@ -339,7 +339,6 @@ export const validateCodingScheme = (
     });
 
   variableCodings.forEach(c => {
-    const varInfo = c.sourceType === 'BASE' ? baseVarById.get(c.id) : undefined;
     const codingValueShape = getCodingValueShape(c);
 
     if (c.sourceType === 'BASE') {

--- a/src/validation/validate-coding-scheme.ts
+++ b/src/validation/validate-coding-scheme.ts
@@ -116,6 +116,10 @@ export const validateCodingScheme = (
   const getBaseVariableValueShape = (
     varInfo: VariableInfo | undefined
   ): CodingValueShape => {
+    if (varInfo?.type === 'no-value') {
+      return { valueType: 'string', multiple: true };
+    }
+
     const multiple = varInfo?.multiple;
     const valuePositionLabels = varInfo?.valuePositionLabels;
 
@@ -339,14 +343,6 @@ export const validateCodingScheme = (
     const codingValueShape = getCodingValueShape(c);
 
     if (c.sourceType === 'BASE') {
-      if (varInfo?.type === 'no-value') {
-        problems.push({
-          type: 'INVALID_SOURCE',
-          breaking: true,
-          variableId: c.alias || c.id,
-          variableLabel: c.label || ''
-        });
-      }
       if (allBaseVariableInfoIds.indexOf(c.id) < 0) {
         problems.push({
           type: 'SOURCE_MISSING',

--- a/test/unit/coding-scheme-factory.test.ts
+++ b/test/unit/coding-scheme-factory.test.ts
@@ -331,7 +331,7 @@ describe('CodingSchemeFactory', () => {
       ).toBe(true);
     });
 
-    test('detects INVALID_SOURCE if BASE variable points to VarInfo of type no-value', () => {
+    test('allows BASE to activate a VarInfo of type no-value', () => {
       const baseVars: VariableInfo[] = [
         { id: 'v1', type: 'no-value' }
       ] as unknown as VariableInfo[];
@@ -340,7 +340,38 @@ describe('CodingSchemeFactory', () => {
       const problems = CodingSchemeFactory.validate(baseVars, [coding]);
       expect(
         problems.some(p => p.type === 'INVALID_SOURCE' && p.breaking)
-      ).toBe(true);
+      ).toBe(false);
+    });
+
+    test('validates an activated no-value variable as a multiple string', () => {
+      const baseVars: VariableInfo[] = [
+        { id: 'v1', type: 'no-value' }
+      ] as unknown as VariableInfo[];
+      const coding = CodingFactory.createCodingVariable('v1');
+      coding.codes = <CodeData[]>[
+        {
+          id: 1,
+          score: 0,
+          label: '',
+          type: 'INTENDED_INCOMPLETE',
+          manualInstruction: '',
+          ruleSetOperatorAnd: false,
+          ruleSets: [{
+            ruleOperatorAnd: false,
+            valueArrayPos: 0,
+            rules: [{ method: 'IS_TRUE' }]
+          }]
+        }
+      ];
+
+      const problems = CodingSchemeFactory.validate(baseVars, [coding]);
+      expect(
+        problems.some(p => [
+          'INVALID_SOURCE',
+          'RULE_PARAMETER_INVALID',
+          'RULESET_VALUE_ARRAY_POS_INVALID'
+        ].includes(p.type))
+      ).toBe(false);
     });
 
     test('detects INVALID_SOURCE if BASE_NO_VALUE variable points to VarInfo not of type no-value', () => {


### PR DESCRIPTION
## Summary

- accept `sourceType: BASE` for a `VariableInfo` with `type: no-value` as an intentional activation
- validate the activated variable with the same synthetic string/multiple value shape used by the Schemer
- keep `BASE_NO_VALUE` inactive semantics and genuine missing-source, type, ID and alias collision errors unchanged
- preserve the alias-shadowing behavior covered since 5.2.1
- prepare `@iqb/responses@5.2.2`

## Tests

- `npm test -- --runInBand test/unit/coding-scheme-factory.test.ts` — 69 tests passed
- `npm run lint`
- `npm run prepare_publish`

Related to iqb-berlin/studio-lite#1463.

This is the first draft in the dependency chain and must be released before the dependent pull requests can refresh their registry-based lockfiles. No package has been published as part of this pull request.
