### PR TITLE
Support explicit null solver results

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,10 @@ Status strings used by this package include (among others) `VALUE_CHANGED`, `COD
 
 ## Versionsänderungen npm-package `@iqb/responses`
 
+### 5.2.2
+- Ein von einem SOLVER-Ausdruck explizit zurückgegebenes `null` wird als `VALUE_CHANGED` weitergegeben und kann über `IS_NULL` oder `RESIDUAL_AUTO` kodiert werden.
+- `NaN`, positive und negative Unendlichkeit sowie andere nichtnumerische SOLVER-Ergebnisse führen weiterhin zu `DERIVE_ERROR`.
+
 ### 5.2.1
 - Ein eindeutiger öffentlicher Alias darf der technischen ID einer anderen Variable entsprechen, sofern deren öffentlicher Bezeichner abweicht. Responses bleiben extern aliasbasiert, während `deriveSources` weiterhin technische IDs referenzieren.
 - Doppelte IDs, doppelte Aliasse und echte öffentliche Kollisionen bleiben ungültig.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@iqb/responses",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@iqb/responses",
-      "version": "5.2.1",
+      "version": "5.2.2",
       "license": "MIT",
       "dependencies": {
         "@iqbspecs/coding-scheme": "^3.4.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@iqb/responses",
   "author": "IQB - Institut zur Qualitätsentwicklung im Bildungswesen",
   "license": "MIT",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "description": "Automatic coding.",
   "scripts": {
     "test": "jest",

--- a/package_npm.json
+++ b/package_npm.json
@@ -1,6 +1,6 @@
 {
   "name": "@iqb/responses",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "author": "IQB - Institut zur Qualitätsentwicklung im Bildungswesen",
   "license": "CC0 1.0",
   "description": "Automatic coding.",

--- a/src/derive/derive-value.ts
+++ b/src/derive/derive-value.ts
@@ -507,19 +507,23 @@ const handleSolver = ({
     return deriveErrorResponse(coding, subformSource);
   }
 
-  if (
-    typeof newValue !== 'number' ||
-    Number.isNaN(newValue) ||
-    newValue === Number.POSITIVE_INFINITY ||
-    newValue === Number.NEGATIVE_INFINITY
-  ) {
-    newValue = null;
+  if (newValue === null) {
+    return <Response>{
+      id: coding.id,
+      value: null,
+      status: CODING_SCHEME_STATUS.VALUE_CHANGED,
+      subform: subformSource
+    };
+  }
+
+  if (typeof newValue !== 'number' || !Number.isFinite(newValue)) {
+    return deriveErrorResponse(coding, subformSource);
   }
 
   return <Response>{
     id: coding.id,
     value: newValue,
-    status: newValue === null ? CODING_SCHEME_STATUS.DERIVE_ERROR : CODING_SCHEME_STATUS.VALUE_CHANGED,
+    status: CODING_SCHEME_STATUS.VALUE_CHANGED,
     subform: subformSource
   };
 };

--- a/test/unit/coding-scheme-factory.test.ts
+++ b/test/unit/coding-scheme-factory.test.ts
@@ -1334,6 +1334,181 @@ describe('CodingSchemeFactory', () => {
       expect(response?.score).toBe(0);
     });
 
+    test('codes an explicit SOLVER null with IS_NULL', () => {
+      const source = CodingFactory.createCodingVariable('v1');
+      const derived: VariableCodingData = {
+        ...CodingFactory.createCodingVariable('d1'),
+        sourceType: 'SOLVER',
+        deriveSources: ['v1'],
+        sourceParameters: {
+          solverExpression: `${solverRef('v1')} > 0 ? 1 : null`,
+          processing: []
+        },
+        codes: <CodeData[]>[
+          {
+            id: 1,
+            score: 1,
+            label: '',
+            type: 'FULL_CREDIT',
+            manualInstruction: '',
+            ruleSetOperatorAnd: false,
+            ruleSets: [
+              {
+                ruleOperatorAnd: true,
+                rules: [{ method: 'IS_NULL', parameters: [] }]
+              }
+            ]
+          },
+          {
+            id: 0,
+            score: 0,
+            label: '',
+            type: 'RESIDUAL_AUTO',
+            manualInstruction: '',
+            ruleSetOperatorAnd: false,
+            ruleSets: []
+          }
+        ]
+      } as VariableCodingData;
+
+      const coded = CodingSchemeFactory.code(
+        [{ id: 'v1', value: 0, status: 'VALUE_CHANGED' } as Response],
+        [source, derived]
+      );
+      const response = coded.find(r => r.id === 'd1');
+
+      expect(response?.status).toBe('CODING_COMPLETE');
+      expect(response?.value).toBeNull();
+      expect(response?.code).toBe(1);
+      expect(response?.score).toBe(1);
+    });
+
+    test('uses RESIDUAL_AUTO for SOLVER null instead of IS_EMPTY or numeric rules', () => {
+      const source = CodingFactory.createCodingVariable('v1');
+      const derived: VariableCodingData = {
+        ...CodingFactory.createCodingVariable('d1'),
+        sourceType: 'SOLVER',
+        deriveSources: ['v1'],
+        sourceParameters: {
+          solverExpression: `${solverRef('v1')} > 0 ? 1 : null`,
+          processing: []
+        },
+        codes: <CodeData[]>[
+          {
+            id: 1,
+            score: 1,
+            label: '',
+            type: 'FULL_CREDIT',
+            manualInstruction: '',
+            ruleSetOperatorAnd: false,
+            ruleSets: [
+              {
+                ruleOperatorAnd: true,
+                rules: [{ method: 'IS_EMPTY', parameters: [] }]
+              }
+            ]
+          },
+          {
+            id: 2,
+            score: 1,
+            label: '',
+            type: 'FULL_CREDIT',
+            manualInstruction: '',
+            ruleSetOperatorAnd: false,
+            ruleSets: [
+              {
+                ruleOperatorAnd: true,
+                rules: [{ method: 'NUMERIC_MATCH', parameters: ['0'] }]
+              }
+            ]
+          },
+          {
+            id: 0,
+            score: 0,
+            label: '',
+            type: 'RESIDUAL_AUTO',
+            manualInstruction: '',
+            ruleSetOperatorAnd: false,
+            ruleSets: []
+          }
+        ]
+      } as VariableCodingData;
+
+      const coded = CodingSchemeFactory.code(
+        [{ id: 'v1', value: 0, status: 'VALUE_CHANGED' } as Response],
+        [source, derived]
+      );
+      const response = coded.find(r => r.id === 'd1');
+
+      expect(response?.status).toBe('CODING_COMPLETE');
+      expect(response?.value).toBeNull();
+      expect(response?.code).toBe(0);
+      expect(response?.score).toBe(0);
+    });
+
+    test('applies an empty policy when a downstream SOLVER consumes a coded null', () => {
+      const source = CodingFactory.createCodingVariable('v1');
+      const nullDerived: VariableCodingData = {
+        ...CodingFactory.createCodingVariable('d1'),
+        sourceType: 'SOLVER',
+        deriveSources: ['v1'],
+        sourceParameters: {
+          solverExpression: `${solverRef('v1')} > 0 ? 1 : null`,
+          processing: []
+        },
+        codes: <CodeData[]>[
+          {
+            id: 1,
+            score: 0,
+            label: '',
+            type: 'FULL_CREDIT',
+            manualInstruction: '',
+            ruleSetOperatorAnd: false,
+            ruleSets: [
+              {
+                ruleOperatorAnd: true,
+                rules: [{ method: 'IS_NULL', parameters: [] }]
+              }
+            ]
+          }
+        ]
+      } as VariableCodingData;
+
+      const downstream: VariableCodingData = {
+        ...CodingFactory.createCodingVariable('d2'),
+        sourceType: 'SOLVER',
+        deriveSources: ['d1'],
+        sourceParameters: {
+          solverExpression: `${solverRef('d1:4')} + 1`,
+          processing: []
+        },
+        codes: <CodeData[]>[
+          {
+            id: 0,
+            score: 0,
+            label: '',
+            type: 'RESIDUAL_AUTO',
+            manualInstruction: '',
+            ruleSetOperatorAnd: false,
+            ruleSets: []
+          }
+        ]
+      } as VariableCodingData;
+
+      const coded = CodingSchemeFactory.code(
+        [{ id: 'v1', value: 0, status: 'VALUE_CHANGED' } as Response],
+        [source, nullDerived, downstream]
+      );
+      const sourceResponse = coded.find(r => r.id === 'd1');
+      const downstreamResponse = coded.find(r => r.id === 'd2');
+
+      expect(sourceResponse?.status).toBe('CODING_COMPLETE');
+      expect(sourceResponse?.value).toBeNull();
+      expect(downstreamResponse?.status).toBe('CODING_COMPLETE');
+      expect(downstreamResponse?.value).toBe(5);
+      expect(downstreamResponse?.code).toBe(0);
+    });
+
     test('marks empty string as INVALID for BASE unless TAKE_EMPTY_AS_VALID is set', () => {
       const v1 = CodingFactory.createCodingVariable('v1');
       v1.sourceParameters = v1.sourceParameters || { processing: [] };

--- a/test/unit/derive-value.test.ts
+++ b/test/unit/derive-value.test.ts
@@ -309,6 +309,47 @@ describe('deriveValue', () => {
     expect(result.value).toBeNull();
   });
 
+  test('SOLVER returns VALUE_CHANGED for an explicit null result', () => {
+    const coding: VariableCodingData = {
+      ...CodingFactory.createCodingVariable('d'),
+      sourceType: 'SOLVER',
+      deriveSources: [],
+      sourceParameters: {
+        solverExpression: 'false ? 1 : null',
+        processing: []
+      },
+      codes: []
+    } as VariableCodingData;
+
+    const result = deriveValue([coding], coding, []);
+    expect(result.status).toBe('VALUE_CHANGED');
+    expect(result.value).toBeNull();
+  });
+
+  test.each([
+    ['NaN', '0 / 0'],
+    ['positive infinity', '1 / 0'],
+    ['negative infinity', '-1 / 0'],
+    ['boolean', 'true'],
+    ['string', '"text"'],
+    ['object', '{ value: 1 }']
+  ])('SOLVER returns DERIVE_ERROR for a %s result', (_label, solverExpression) => {
+    const coding: VariableCodingData = {
+      ...CodingFactory.createCodingVariable('d'),
+      sourceType: 'SOLVER',
+      deriveSources: [],
+      sourceParameters: {
+        solverExpression,
+        processing: []
+      },
+      codes: []
+    } as VariableCodingData;
+
+    const result = deriveValue([coding], coding, []);
+    expect(result.status).toBe('DERIVE_ERROR');
+    expect(result.value).toBeNull();
+  });
+
   test('SOLVER returns DERIVE_ERROR if expression uses var not in deriveSources', () => {
     const v2 = CodingFactory.createCodingVariable('ID_1');
     v2.alias = 'v2';


### PR DESCRIPTION
## Summary

- preserve an explicit `null` returned by a SOLVER expression as `VALUE_CHANGED`
- keep `NaN`, infinities, and other non-numeric results as `DERIVE_ERROR`
- cover `IS_NULL`, `RESIDUAL_AUTO`, downstream empty policies, and invalid math.js results
- prepare the `@iqb/responses` 5.2.2 patch release

## Root cause

The solver normalized every non-number, including an intentional `null`, to the same error result. This prevented normal coding rules from handling an explicit null value.

## Validation

- `npm test -- --runInBand` (299 tests)
- `npm run lint`
- `npm run prepare_publish`

Relates to iqb-berlin/coding-components#141.
