### PR TITLE
Fix published package dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,9 @@ jobs:
       - name: Build project
         run: npm run prepare_publish
 
+      - name: Verify packed package
+        run: npm run test:package
+
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test": "jest",
     "test_coding": "jest test/coding",
     "test:coverage": "jest --coverage",
+    "test:package": "node scripts/verify-package.js",
     "test_coding2text": "cd test && ts-node test-code2text case1",
     "test_getBaseVarsList": "cd test && ts-node test-getBaseVarsList get-base-vars-case",
     "prepare_publish": "rm -rf dist/* && tsc --module commonjs && cp ./package_npm.json ./dist/package.json && cp ./README.md ./dist",

--- a/package_npm.json
+++ b/package_npm.json
@@ -5,7 +5,10 @@
   "license": "CC0 1.0",
   "description": "Automatic coding.",
   "dependencies": {
-    "mathjs": "^12.4.2"
+    "@iqbspecs/coding-scheme": "^3.4.1",
+    "@iqbspecs/response": "^2.0.0",
+    "@iqbspecs/variable-info": "^1.3.0",
+    "mathjs": "^15.1.0"
   },
   "repository": {
     "type": "git",

--- a/scripts/verify-package.js
+++ b/scripts/verify-package.js
@@ -1,0 +1,117 @@
+const assert = require('node:assert/strict');
+const { execFileSync } = require('node:child_process');
+const {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync
+} = require('node:fs');
+const { tmpdir } = require('node:os');
+const { join, resolve } = require('node:path');
+
+const repositoryRoot = resolve(__dirname, '..');
+const distDirectory = join(repositoryRoot, 'dist');
+const npmExecutable = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+
+const readJson = filePath => JSON.parse(readFileSync(filePath, 'utf8'));
+
+const rootManifest = readJson(join(repositoryRoot, 'package.json'));
+const publishManifest = readJson(join(distDirectory, 'package.json'));
+
+assert.equal(
+  publishManifest.version,
+  rootManifest.version,
+  'Published package version must match the root package version.'
+);
+assert.deepEqual(
+  publishManifest.dependencies,
+  rootManifest.dependencies,
+  'Published package dependencies must match the root package dependencies.'
+);
+
+const temporaryRoot = mkdtempSync(join(tmpdir(), 'iqb-responses-package-'));
+
+try {
+  const packOutput = execFileSync(
+    npmExecutable,
+    ['pack', distDirectory, '--json', '--pack-destination', temporaryRoot],
+    {
+      cwd: repositoryRoot,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'inherit']
+    }
+  );
+  const packResult = JSON.parse(packOutput);
+  assert.equal(packResult.length, 1, 'Expected npm pack to create one tarball.');
+
+  const tarballPath = join(temporaryRoot, packResult[0].filename);
+  const consumerDirectory = join(temporaryRoot, 'consumer');
+  mkdirSync(consumerDirectory);
+  writeFileSync(
+    join(consumerDirectory, 'package.json'),
+    JSON.stringify({ name: 'package-consumer', private: true }, null, 2)
+  );
+
+  execFileSync(
+    npmExecutable,
+    [
+      'install',
+      '--ignore-scripts',
+      '--no-audit',
+      '--no-fund',
+      '--package-lock=false',
+      tarballPath
+    ],
+    { cwd: consumerDirectory, stdio: 'inherit' }
+  );
+
+  const runtimeCheck = [
+    "const responses = require('@iqb/responses');",
+    "for (const name of ['CodingFactory', 'CodingSchemeFactory', 'VariableList']) {",
+    "  if (typeof responses[name] !== 'function') {",
+    "    throw new Error(`Missing public export: ${name}`);",
+    '  }',
+    '}'
+  ].join('\n');
+  execFileSync(process.execPath, ['-e', runtimeCheck], {
+    cwd: consumerDirectory,
+    stdio: 'inherit'
+  });
+
+  writeFileSync(
+    join(consumerDirectory, 'consumer.ts'),
+    [
+      "import { CodingFactory, CodingSchemeFactory, VariableList } from '@iqb/responses';",
+      'void CodingFactory;',
+      'void CodingSchemeFactory;',
+      'void VariableList;'
+    ].join('\n')
+  );
+  writeFileSync(
+    join(consumerDirectory, 'tsconfig.json'),
+    JSON.stringify(
+      {
+        compilerOptions: {
+          module: 'commonjs',
+          moduleResolution: 'node',
+          noEmit: true,
+          skipLibCheck: false,
+          strict: true,
+          target: 'ES2020'
+        },
+        files: ['consumer.ts']
+      },
+      null,
+      2
+    )
+  );
+
+  const typescriptCompiler = require.resolve('typescript/bin/tsc');
+  execFileSync(process.execPath, [typescriptCompiler, '--project', 'tsconfig.json'], {
+    cwd: consumerDirectory,
+    stdio: 'inherit'
+  });
+} finally {
+  rmSync(temporaryRoot, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary

- declare the required `@iqbspecs/*` dependencies in the published package manifest
- align the published `mathjs` dependency with the development manifest
- add an isolated smoke test for the actual npm tarball
- run the package smoke test in CI before uploading the build artifact

## Root cause

`prepare_publish` replaces the root manifest with `package_npm.json` inside `dist`. That publish manifest only declared `mathjs`, so consumers did not receive the `@iqbspecs/*` packages referenced by the runtime and declaration files. The existing tests run against the development installation and therefore could not detect the incomplete tarball.

## Impact

Consumers will receive all dependencies required to load and type-check `@iqb/responses`. The new smoke test packs `dist`, installs it in an isolated temporary project, checks public runtime exports, and compiles a TypeScript consumer with library checking enabled.

This PR does not change the package version and does not publish a new npm release.

## Validation

- `npm run lint`
- `npm run test:coverage` — 299 tests passed
- `npm run prepare_publish`
- `npm run test:package`
- `node --check scripts/verify-package.js`
